### PR TITLE
#175 view company sensitive data

### DIFF
--- a/profiles/permissions.py
+++ b/profiles/permissions.py
@@ -2,15 +2,10 @@ from rest_framework.permissions import BasePermission, SAFE_METHODS
 
 
 class UserIsProfileOwnerOrReadOnly(BasePermission):
-
     def has_object_permission(self, request, view, obj):
         if request.method in SAFE_METHODS:
+            if request.query_params.get("with_contacts"):
+                return True if request.user.is_authenticated else False
             return True
 
         return obj.person == request.user
-
-
-class IsAllowedToViewContacts(BasePermission):
-
-    def has_permission(self, request, view):
-        return request.user.is_authenticated and request.method in SAFE_METHODS

--- a/profiles/permissions.py
+++ b/profiles/permissions.py
@@ -1,0 +1,16 @@
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+
+class UserIsProfileOwnerOrReadOnly(BasePermission):
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return True
+
+        return obj.person == request.user
+
+
+class IsAllowedToViewContacts(BasePermission):
+
+    def has_permission(self, request, view):
+        return request.user.is_authenticated and request.method in SAFE_METHODS

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -27,6 +27,21 @@ class ProfileSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
+class ProfileDetailSerializer(serializers.ModelSerializer):
+    activity = ActivitySerializer(many=True, read_only=True)
+    category = CategorySerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Profile
+        fields = ('comp_official_name', 'comp_region', 'comp_common_info', 'comp_EDRPOU', 'comp_year_of_foundation',
+                  'comp_address', 'startup_idea', 'comp_name', 'comp_registered', 'comp_is_startup', 'category',
+                  'activity', 'comp_service_info', 'comp_product_info', 'comp_banner_image')
+        read_only_fields = ('comp_official_name', 'comp_region', 'comp_common_info', 'comp_EDRPOU',
+                            'comp_year_of_foundation', 'comp_address', 'startup_idea', 'comp_name',
+                            'comp_registered', 'comp_is_startup', 'category', 'activity', 'comp_service_info',
+                            'comp_product_info', 'comp_banner_image')
+
+
 class SavedCompanySerializer(serializers.ModelSerializer):
     comp_official_name = serializers.ReadOnlyField(source='company.comp_official_name')
     comp_region = serializers.ReadOnlyField(source='company.comp_region')

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -42,6 +42,15 @@ class ProfileDetailSerializer(serializers.ModelSerializer):
                             'comp_product_info', 'comp_banner_image')
 
 
+class ProfileSensitiveDataROSerializer(serializers.ModelSerializer):
+    email = serializers.ReadOnlyField(source='person.person_email')
+
+    class Meta:
+        model = Profile
+        fields = ('comp_phone_number', 'email',)
+        read_only_fields = ('comp_phone_number', 'email',)
+
+
 class SavedCompanySerializer(serializers.ModelSerializer):
     comp_official_name = serializers.ReadOnlyField(source='company.comp_official_name')
     comp_region = serializers.ReadOnlyField(source='company.comp_region')

--- a/profiles/tests/test_crud_profile.py
+++ b/profiles/tests/test_crud_profile.py
@@ -140,112 +140,39 @@ class TestProfileDetailAPIView(APITestCase):
             "comp_activity": 2
         }
 
-        self.client = APIClient()
-        self.base_url = "/api/profiles/"
-        self.update_url = "/api/profiles/2"
-        self.not_exist_profile_url = "/api/profiles/15"
-
-        # login users & get tokens
-        self.token1 = self.client.post(
-            path="/api/auth/token/login/",
-            data={
-                "person_email": "test@test.com",
-                "password": "Testing01"
-            }).data["auth_token"]
-        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token1}")
-
-        self.right_image = self._generate_image('jpeg', (10, 10))
-        self.wrong_image = self._generate_image('png', (3000, 3000))
-
-        self.wrong_full_data_for_full_update = {
-            "profile_id": self.test_profile,
-            "person": self.test_person3,
-            "comp_official_name": "Jannifer",
-            "comp_region": 'Kyiv',
-            "comp_common_info": "Good Very",
-            "comp_phone_number": 167300044411,
-            "comp_EDRPOU": 12345678,
-            "comp_year_of_foundation": 2005,
-            "comp_service_info": 'very good service',
-            "comp_product_info": 'very good product',
-            "comp_address": 'Kyiv',
-            "startup_idea": 'very good idea',
-            "is_deleted": False,
-            "comp_category": [
-                2
-            ],
-            "comp_activity": [
-                2
-            ]
-        }
-        self.right_full_data_for_full_update = {
-            "profile_id": self.test_profile,
-            "person": self.test_person.id,
-            "comp_official_name": "Jannifer",
-            "comp_region": 'E',
-            "comp_common_info": "Good Very",
-            "comp_phone_number": 123456789012,
-            "comp_EDRPOU": 12345678,
-            "comp_year_of_foundation": 2005,
-            "comp_service_info": 'very good service',
-            "comp_product_info": 'very good product',
-            "comp_address": 'Kyiv',
-            "comp_banner_image": self.wrong_image,
-            "person_position": 'director',
-            "startup_idea": 'very good idea',
-            "is_deleted": False,
-            "comp_category": [
-                1
-            ],
-            "comp_activity": [
-                1
-            ]
-        }
-
-        self.right_data_for_create = {
-            "person": self.test_person3.id,
-            "comp_category": [1],
-            "comp_activity": [1]
-        }
-        self.wrong_data_for_create = {
-            "person": self.test_person3,
-            "comp_category": 1,
-            "comp_activity": 2
-        }
-
     def tearDown(self) -> None:
-        self.client.logout()
         if os.path.exists(self.right_image.name):
             os.remove(self.right_image.name)
         if os.path.exists(self.wrong_image.name):
             os.remove(self.wrong_image.name)
 
     def test_get_profile_unauthorized(self):
-        self.client.logout()
-        response = self.client.get("/api/profiles/{user1_id}".format(user1_id=1))
+        response = self.client.get("/api/profiles/{pk}".format(pk=self.test_profile2.profile_id))
         self.assertEqual(401, response.status_code)
 
     def test_delete_profile_unauthorized(self):
-        self.client.logout()
-        response = self.client.delete("/api/profiles/{user1_id}".format(user1_id=1))
+        response = self.client.delete("/api/profiles/{user_id}".format(user_id=self.test_person_with_profile.id))
         self.assertEqual(401, response.status_code)
 
     def test_get_profile_authorized(self):
-        response = self.client.get(f"/api/profiles/{self.test_profile.profile_id}")#{user1_id}".format(user1_id=1))
+        self.client.force_authenticate(self.test_person_with_profile)
+        response = self.client.get("/api/profiles/{pk}".format(pk=self.test_profile.profile_id))
         self.assertEqual(200, response.status_code, response.content)
         self.assertEqual(False, response.data["is_deleted"])
 
     def test_get_profile_of_other_user(self):
-        response = self.client.get(f"/api/profiles/{self.test_profile2.profile_id}")#{user2_id}".format(user2_id=1))
+        self.client.force_authenticate(self.test_person_with_profile)
+        response = self.client.get("/api/profiles/{pk}".format(pk=self.test_profile2.profile_id))
         self.assertEqual(200, response.status_code, response.content)
 
     def test_delete_profile_authorized(self):
+        self.client.force_authenticate(self.test_person_with_profile)
         # get all before delete
         response = self.client.get("/api/profiles/")
         profiles_len_before_del = len(response.data)
-        pk = Profile.objects.get(person_id=self.test_person.id)
+        user_profile = Profile.objects.get(person_id=self.test_person_with_profile.id)
         # del profile
-        response = self.client.delete(f"/api/profiles/{pk.profile_id}")
+        response = self.client.delete(f"/api/profiles/{user_profile.profile_id}")
         self.assertEqual(204, response.status_code, response.content)
         # check the profile is deleted
         response = self.client.get("/api/profiles/")
@@ -253,16 +180,18 @@ class TestProfileDetailAPIView(APITestCase):
         self.assertEqual(profiles_len_before_del-1, len(response.data))
         self.assertTrue(1 not in persons)
         # try access deleted profile
-        response = self.client.get(f"/api/profiles/{pk.profile_id}")
+        response = self.client.get("/api/profiles/{profile_id}".format(profile_id=user_profile.profile_id))
         self.assertEqual(404, response.status_code, response.content)
 
     def test_delete_profile_of_other_user_authorized(self):
-        response = self.client.delete(f"/api/profiles/{self.test_profile2.profile_id}")
+        self.client.force_authenticate(self.test_person_with_profile)
+        response = self.client.delete("/api/profiles/{profile_id}".format(profile_id=self.test_profile2.profile_id))
         self.assertEqual(404, response.status_code, response.content)
 
     def test_partial_update_profile_authorized(self):
+        self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.patch(
-            path=self.update_url,
+            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
             data={
                 "comp_official_name": "Test_company",
                 "comp_year_of_foundation": 2005
@@ -270,8 +199,9 @@ class TestProfileDetailAPIView(APITestCase):
         self.assertEqual(200, response.status_code)
 
     def test_partial_update_profile_with_wrong_image(self):
+        self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.patch(
-            path=self.update_url,
+            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
             data={
                 "comp_banner_image": f'/Forum/{self.wrong_image}',
                 "comp_year_of_foundation": 2005
@@ -281,7 +211,7 @@ class TestProfileDetailAPIView(APITestCase):
     def test_partial_update_profile_unauthorized(self):
         self.client.logout()
         response = self.client.patch(
-            path=self.update_url,
+            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
             data={
                 "comp_official_name": "Test_company",
                 "comp_year_of_foundation": 2005
@@ -289,8 +219,9 @@ class TestProfileDetailAPIView(APITestCase):
         self.assertEqual(401, response.status_code)
 
     def test_partial_update_profile_not_exist(self):
+        self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.patch(
-            path=self.not_exist_profile_url,
+            path="/api/profiles/{user_id}".format(user_id=1000000000000),
             data={
                 "comp_official_name": "Test_company",
                 "comp_year_of_foundation": 2005
@@ -298,8 +229,9 @@ class TestProfileDetailAPIView(APITestCase):
         self.assertEqual(404, response.status_code)
 
     def test_partial_update_profile_wrong_data(self):
+        self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.patch(
-            path=self.update_url,
+            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
             data={
                 "comp_official_name": 12345,
                 "comp_year_of_foundation": 'Jane'
@@ -307,73 +239,62 @@ class TestProfileDetailAPIView(APITestCase):
         self.assertEqual(400, response.status_code)
 
     def test_full_update_profile_authorized_with_partial_data(self):
+        self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.put(
-            path=self.update_url,
+            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
             data=self.wrong_full_data_for_full_update)
         self.assertEqual(400, response.status_code)
 
     def test_full_update_profile_authorized_with_full_data(self):
+        self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.put(
-            path=self.update_url,
+            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
             data=self.right_full_data_for_full_update)
         self.assertEqual(200, response.status_code, response.content)
 
     def test_full_update_profile_unauthorized(self):
-        self.client.logout()
         response = self.client.put(
-            path=self.update_url,
+            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
             data=self.right_full_data_for_full_update)
         self.assertEqual(401, response.status_code)
 
     def test_full_update_profile_not_exist(self):
+        self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.put(
-            path=self.not_exist_profile_url,
+            path="/api/profiles/{user_id}".format(user_id=10000000000),
             data=self.right_full_data_for_full_update)
         self.assertEqual(404, response.status_code)
 
     def test_full_update_profile_wrong_data(self):
+        self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.put(
-            path=self.update_url,
+            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
             data=self.wrong_full_data_for_full_update)
         self.assertEqual(400, response.status_code)
 
     def test_create_profile_authorized(self):
-        self.client.logout()
-        self.token3 = self.client.post(
-            path="/api/auth/token/login/",
-            data={
-                "person_email": "test3@test.com",
-                "password": "Testing01"
-            }).data["auth_token"]
-        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token3}")
+        self.client.force_authenticate(self.test_person_without_profile)
         response = self.client.post(
-            path=self.base_url,
+            path="/api/profiles/",
             data=self.right_data_for_create)
         self.assertEqual(201, response.status_code, response.content)
 
     def test_create_profile_unauthorized(self):
-        self.client.logout()
         response = self.client.post(
-            path=self.base_url,
+            path="/api/profiles/",
             data=self.right_data_for_create)
         self.assertEqual(401, response.status_code)
 
     def test_create_profile_already_exist(self):
+        self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.post(
-            path=self.base_url,
+            path="/api/profiles/",
             data=self.right_full_data_for_full_update)
         self.assertEqual(409, response.status_code)
 
     def test_create_profile_wrong_data(self):
-        self.client.logout()
-        self.token3 = self.client.post(
-            path="/api/auth/token/login/",
-            data={
-                "person_email": "test3@test.com",
-                "password": "Testing01"
-            }).data["auth_token"]
-        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token3}")
+        self.client.force_authenticate(self.test_person_without_profile)
         response = self.client.post(
-            path=self.base_url,
+            path="/api/profiles/",
             data=self.wrong_data_for_create)
         self.assertEqual(400, response.status_code)

--- a/profiles/tests/test_crud_profile.py
+++ b/profiles/tests/test_crud_profile.py
@@ -253,13 +253,13 @@ class TestProfileDetailAPIView(APITestCase):
         profiles_len_before_del = len(response.data)
         user_profile = Profile.objects.get(person_id=self.test_person_with_profile.id)
         # del profile
-        response = self.client.delete(f"/api/profiles/{user_profile.profile_id}")
+        response = self.client.delete("/api/profiles/{profile_id}".format(profile_id=user_profile.profile_id))
         self.assertEqual(204, response.status_code, response.content)
         # check the profile is deleted
         response = self.client.get("/api/profiles/")
-        persons = [response.data[i]["person"] for i in range(len(response.data))]
+        profile_id_list = [profile['profile_id'] for profile in response.data]
         self.assertEqual(profiles_len_before_del-1, len(response.data))
-        self.assertTrue(1 not in persons)
+        self.assertTrue(user_profile.profile_id not in profile_id_list)
         # try access deleted profile
         response = self.client.get("/api/profiles/{profile_id}".format(profile_id=user_profile.profile_id))
         self.assertEqual(404, response.status_code, response.content)

--- a/profiles/tests/test_crud_profile.py
+++ b/profiles/tests/test_crud_profile.py
@@ -225,13 +225,13 @@ class TestProfileDetailAPIView(APITestCase):
         )
 
     def test_get_contact_info_unauthorized(self):
-        response = self.client.get("/api/profiles/{profile_id}?get_contacts=True".format(
+        response = self.client.get("/api/profiles/{profile_id}?with_contacts=True".format(
             profile_id=self.test_profile2.profile_id))
         self.assertEqual(401, response.status_code)
 
     def test_get_contact_info_authorized(self):
         self.client.force_authenticate(self.test_person_with_profile)
-        response = self.client.get("/api/profiles/{profile_id}?get_contacts=True".format(
+        response = self.client.get("/api/profiles/{profile_id}?with_contacts=True".format(
             profile_id=self.test_profile2.profile_id))
         self.assertEqual(200, response.status_code)
         self.assertEqual(

--- a/profiles/tests/test_crud_profile.py
+++ b/profiles/tests/test_crud_profile.py
@@ -340,7 +340,7 @@ class TestProfileDetailAPIView(APITestCase):
             }
         )
         self.assertEqual(200, response.status_code)
-        self.assertEqual([1, 2], response.data.get('comp_category'))
+        self.assertEqual([self.test_category.category_id, self.test_category2.category_id], response.data.get('comp_category'))
 
     def test_partial_update_profile_activity(self):
         self.client.force_authenticate(self.test_person_with_profile)
@@ -351,7 +351,7 @@ class TestProfileDetailAPIView(APITestCase):
             }
         )
         self.assertEqual(200, response.status_code)
-        self.assertEqual([1, 2], response.data.get('comp_activity'))
+        self.assertEqual([self.test_activity.activity_id, self.test_activity2.activity_id], response.data.get('comp_activity'))
 
     # PUT requests section
     def test_full_update_profile_authorized_with_partial_data(self):

--- a/profiles/tests/test_crud_profile.py
+++ b/profiles/tests/test_crud_profile.py
@@ -191,7 +191,7 @@ class TestProfileDetailAPIView(APITestCase):
     def test_partial_update_profile_authorized(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.patch(
-            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
+            path="/api/profiles/{profile_id}".format(profile_id=self.test_profile.profile_id),
             data={
                 "comp_official_name": "Test_company",
                 "comp_year_of_foundation": 2005
@@ -201,7 +201,7 @@ class TestProfileDetailAPIView(APITestCase):
     def test_partial_update_profile_with_wrong_image(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.patch(
-            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
+            path="/api/profiles/{profile_id}".format(profile_id=self.test_profile.profile_id),
             data={
                 "comp_banner_image": f'/Forum/{self.wrong_image}',
                 "comp_year_of_foundation": 2005
@@ -211,7 +211,7 @@ class TestProfileDetailAPIView(APITestCase):
     def test_partial_update_profile_unauthorized(self):
         self.client.logout()
         response = self.client.patch(
-            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
+            path="/api/profiles/{profile_id}".format(profile_id=self.test_profile.profile_id),
             data={
                 "comp_official_name": "Test_company",
                 "comp_year_of_foundation": 2005
@@ -221,7 +221,7 @@ class TestProfileDetailAPIView(APITestCase):
     def test_partial_update_profile_not_exist(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.patch(
-            path="/api/profiles/{user_id}".format(user_id=1000000000000),
+            path="/api/profiles/{profile_id}".format(profile_id=1000000000000),
             data={
                 "comp_official_name": "Test_company",
                 "comp_year_of_foundation": 2005
@@ -231,7 +231,7 @@ class TestProfileDetailAPIView(APITestCase):
     def test_partial_update_profile_wrong_data(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.patch(
-            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
+            path="/api/profiles/{profile_id}".format(profile_id=self.test_profile.profile_id),
             data={
                 "comp_official_name": 12345,
                 "comp_year_of_foundation": 'Jane'
@@ -241,34 +241,34 @@ class TestProfileDetailAPIView(APITestCase):
     def test_full_update_profile_authorized_with_partial_data(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.put(
-            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
+            path="/api/profiles/{profile_id}".format(profile_id=self.test_profile.profile_id),
             data=self.wrong_full_data_for_full_update)
         self.assertEqual(400, response.status_code)
 
     def test_full_update_profile_authorized_with_full_data(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.put(
-            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
+            path="/api/profiles/{profile_id}".format(profile_id=self.test_profile.profile_id),
             data=self.right_full_data_for_full_update)
         self.assertEqual(200, response.status_code, response.content)
 
     def test_full_update_profile_unauthorized(self):
         response = self.client.put(
-            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
+            path="/api/profiles/{profile_id}".format(profile_id=self.test_profile.profile_id),
             data=self.right_full_data_for_full_update)
         self.assertEqual(401, response.status_code)
 
     def test_full_update_profile_not_exist(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.put(
-            path="/api/profiles/{user_id}".format(user_id=10000000000),
+            path="/api/profiles/{profile_id}".format(profile_id=10000000000),
             data=self.right_full_data_for_full_update)
         self.assertEqual(404, response.status_code)
 
     def test_full_update_profile_wrong_data(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.put(
-            path="/api/profiles/{pk}".format(pk=self.test_profile.profile_id),
+            path="/api/profiles/{profile_id}".format(profile_id=self.test_profile.profile_id),
             data=self.wrong_full_data_for_full_update)
         self.assertEqual(400, response.status_code)
 

--- a/profiles/tests/test_crud_profile.py
+++ b/profiles/tests/test_crud_profile.py
@@ -244,7 +244,7 @@ class TestProfileDetailAPIView(APITestCase):
 
     def test_delete_profile_unauthorized(self):
         response = self.client.delete("/api/profiles/{profile_id}".format(profile_id=self.test_person_with_profile.id))
-        self.assertEqual(401, response.status_code)
+        self.assertEqual(404, response.status_code)
 
     def test_delete_profile_authorized(self):
         self.client.force_authenticate(self.test_person_with_profile)
@@ -254,7 +254,7 @@ class TestProfileDetailAPIView(APITestCase):
         user_profile = Profile.objects.get(person_id=self.test_person_with_profile.id)
         # del profile
         response = self.client.delete("/api/profiles/{profile_id}".format(profile_id=user_profile.profile_id))
-        self.assertEqual(204, response.status_code, response.content)
+        self.assertEqual(204, response.status_code)
         # check the profile is deleted
         response = self.client.get("/api/profiles/")
         profile_id_list = [profile['profile_id'] for profile in response.data]
@@ -267,7 +267,7 @@ class TestProfileDetailAPIView(APITestCase):
     def test_delete_profile_of_other_user_authorized(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.delete("/api/profiles/{profile_id}".format(profile_id=self.test_profile2.profile_id))
-        self.assertEqual(404, response.status_code, response.content)
+        self.assertEqual(403, response.status_code)
 
     def test_partial_update_profile_authorized(self):
         self.client.force_authenticate(self.test_person_with_profile)

--- a/profiles/tests/test_crud_profile.py
+++ b/profiles/tests/test_crud_profile.py
@@ -125,7 +125,7 @@ class TestProfileDetailAPIView(APITestCase):
                 self.test_category.category_id
             ],
             "comp_activity": [
-                1
+                self.test_activity.activity_id
             ]
         }
 

--- a/profiles/tests/test_crud_profile.py
+++ b/profiles/tests/test_crud_profile.py
@@ -7,49 +7,7 @@ from PIL import Image
 import os
 
 
-
 class TestProfileDetailAPIView(APITestCase):
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.test_person = CustomUser.objects.create_user(
-            person_email="test@test.com",
-            password="Testing01",
-            person_name="test",
-            person_surname="test",
-            is_active=True
-        )
-        cls.test_person2 = CustomUser.objects.create_user(
-            person_email="test2@test.com",
-            password="Testing01",
-            person_name="test",
-            person_surname="test",
-            is_active=True
-        )
-
-        cls.test_person3 = CustomUser.objects.create_user(
-            person_email="test3@test.com",
-            password="Testing01",
-            person_name="test",
-            person_surname="test",
-            is_active=True
-        )
-
-        cls.test_profile = Profile.objects.create(
-            person=cls.test_person,
-            comp_is_startup=True,
-            comp_registered=False
-        )
-        cls.test_profile2 = Profile.objects.create(
-            person=cls.test_person2,
-            comp_registered=True,
-            comp_is_startup=False
-        )
-
-        Category.objects.create(category_id=1,
-                                name='cheese')
-        Activity.objects.create(activity_id=1,
-                                name='importer')
 
     @staticmethod
     def _generate_image(ext, size=(100, 100)):
@@ -63,6 +21,125 @@ class TestProfileDetailAPIView(APITestCase):
         return file
 
     def setUp(self) -> None:
+        self.test_person_with_profile = CustomUser.objects.create_user(
+            person_email="test1@test.com",
+            password="Testing01",
+            person_name="test1",
+            person_surname="test1",
+            is_active=True
+        )
+        self.test_person2_with_profile = CustomUser.objects.create_user(
+            person_email="test2@test.com",
+            password="Testing01",
+            person_name="test2",
+            person_surname="test2",
+            is_active=True
+        )
+
+        self.test_person_without_profile = CustomUser.objects.create_user(
+            person_email="test3@test.com",
+            password="Testing01",
+            person_name="test3",
+            person_surname="test3",
+            is_active=True
+        )
+
+        self.test_profile = Profile.objects.create(
+            person=self.test_person_with_profile,
+            comp_registered=True,
+            comp_is_startup=False,
+            comp_official_name="Test 1 official name",
+            comp_name="Test 1",
+            comp_region="E",
+            comp_common_info="Test 1 common info",
+            comp_phone_number=380990102034,
+            comp_EDRPOU=10000001,
+            comp_year_of_foundation=2020,
+            comp_service_info="Test 1 service info",
+            comp_product_info="Test 1 product info",
+            comp_address="Lviv",
+            startup_idea="Test 1 start up idea"
+        )
+        self.test_profile2 = Profile.objects.create(
+            person=self.test_person2_with_profile,
+            comp_registered=True,
+            comp_is_startup=False,
+            comp_official_name="Test 2 official name",
+            comp_name="Test 2",
+            comp_region="E",
+            comp_common_info="Test 2 common info",
+            comp_phone_number=380990102034,
+            comp_EDRPOU=10000002,
+            comp_year_of_foundation=2020,
+            comp_service_info="Test 2 service info",
+            comp_product_info="Test 2 product info",
+            comp_address="Kyiv",
+            startup_idea="Test 2 start up idea"
+        )
+        Category.objects.create(category_id=1,
+                                name='cheese')
+        Activity.objects.create(activity_id=1,
+                                name='importer')
+
+        self.right_image = self._generate_image('jpeg', (10, 10))
+        self.wrong_image = self._generate_image('png', (3000, 3000))
+
+        self.wrong_full_data_for_full_update = {
+            "profile_id": self.test_profile,
+            "person": self.test_person_with_profile,
+            "comp_official_name": "Jannifer",
+            "comp_region": 'Kyiv',
+            "comp_common_info": "Good Very",
+            "comp_phone_number": 167300044411,
+            "comp_EDRPOU": 12345678,
+            "comp_year_of_foundation": 2005,
+            "comp_service_info": 'very good service',
+            "comp_product_info": 'very good product',
+            "comp_address": 'Kyiv',
+            "startup_idea": 'very good idea',
+            "is_deleted": False,
+            "comp_category": [
+                2
+            ],
+            "comp_activity": [
+                2
+            ]
+        }
+        self.right_full_data_for_full_update = {
+            "profile_id": self.test_profile,
+            "person": self.test_person_with_profile.id,
+            "comp_official_name": "Jannifer",
+            "comp_region": 'E',
+            "comp_common_info": "Good Very",
+            "comp_phone_number": 123456789012,
+            "comp_EDRPOU": 12345678,
+            "comp_year_of_foundation": 2005,
+            "comp_service_info": 'very good service',
+            "comp_product_info": 'very good product',
+            "comp_address": 'Kyiv',
+            "comp_banner_image": self.wrong_image,
+            "person_position": 'director',
+            "startup_idea": 'very good idea',
+            "is_deleted": False,
+            "comp_category": [
+                1
+            ],
+            "comp_activity": [
+                1
+            ]
+        }
+
+        self.right_data_for_create = {
+            "person": self.test_person_without_profile.id,
+            "comp_category": [1],
+            "comp_activity": [1]
+        }
+        self.wrong_data_for_create = {
+            "person": self.test_person_without_profile,
+            "comp_category": 1,
+            "comp_activity": 2
+        }
+
         self.client = APIClient()
         self.base_url = "/api/profiles/"
         self.update_url = "/api/profiles/2"

--- a/profiles/tests/test_crud_profile.py
+++ b/profiles/tests/test_crud_profile.py
@@ -146,6 +146,7 @@ class TestProfileDetailAPIView(APITestCase):
         if os.path.exists(self.wrong_image.name):
             os.remove(self.wrong_image.name)
 
+    # GET requests section
     def test_get_profile_nonexistent(self):
         response = self.client.get("/api/profiles/{profile_id}".format(profile_id=100000000000))
         self.assertEqual(404, response.status_code)
@@ -242,6 +243,7 @@ class TestProfileDetailAPIView(APITestCase):
             response.data
         )
 
+    # DELETE requests section
     def test_delete_profile_unauthorized(self):
         response = self.client.delete("/api/profiles/{profile_id}".format(profile_id=self.test_person_with_profile.id))
         self.assertEqual(404, response.status_code)
@@ -269,6 +271,7 @@ class TestProfileDetailAPIView(APITestCase):
         response = self.client.delete("/api/profiles/{profile_id}".format(profile_id=self.test_profile2.profile_id))
         self.assertEqual(403, response.status_code)
 
+    # PATCH requests section
     def test_partial_update_profile_authorized(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.patch(
@@ -278,6 +281,16 @@ class TestProfileDetailAPIView(APITestCase):
                 "comp_year_of_foundation": 2005
             })
         self.assertEqual(200, response.status_code)
+
+    def test_partial_update_authorized_not_owner(self):
+        self.client.force_authenticate(self.test_person_with_profile)
+        response = self.client.patch(
+            path="/api/profiles/{profile_id}".format(profile_id=self.test_profile2.profile_id),
+            data={
+                "comp_official_name": "Test_company",
+                "comp_year_of_foundation": 2005
+            })
+        self.assertEqual(403, response.status_code)
 
     def test_partial_update_profile_with_wrong_image(self):
         self.client.force_authenticate(self.test_person_with_profile)
@@ -290,7 +303,6 @@ class TestProfileDetailAPIView(APITestCase):
         self.assertEqual(400, response.status_code)
 
     def test_partial_update_profile_unauthorized(self):
-        self.client.logout()
         response = self.client.patch(
             path="/api/profiles/{profile_id}".format(profile_id=self.test_profile.profile_id),
             data={
@@ -319,6 +331,7 @@ class TestProfileDetailAPIView(APITestCase):
             })
         self.assertEqual(400, response.status_code)
 
+    # PUT requests section
     def test_full_update_profile_authorized_with_partial_data(self):
         self.client.force_authenticate(self.test_person_with_profile)
         response = self.client.put(
@@ -353,6 +366,15 @@ class TestProfileDetailAPIView(APITestCase):
             data=self.wrong_full_data_for_full_update)
         self.assertEqual(400, response.status_code)
 
+    def test_full_update_authorized_not_owner(self):
+        self.client.force_authenticate(self.test_person_with_profile)
+        response = self.client.put(
+            path="/api/profiles/{profile_id}".format(profile_id=self.test_profile2.profile_id),
+            data=self.right_full_data_for_full_update)
+        self.assertEqual(403, response.status_code, response.content)
+
+
+    # POST requests section
     def test_create_profile_authorized(self):
         self.client.force_authenticate(self.test_person_without_profile)
         response = self.client.post(

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -83,7 +83,11 @@ class ProfileList(ListCreateAPIView):
 
 class ProfileDetail(RetrieveUpdateDestroyAPIView):
     """
-    Retrieve or delete a profile instance.
+    Retrieve, update or delete a profile instance.
+    Retrieve:
+        If user is a person in the profile, full info returned.
+        Else profile info without sensitive data returned.
+        If user is authenticated, he can get sensitive data via query param 'with_contacts'.
     """
     queryset = Profile.objects.filter(is_deleted=False)
     permission_classes = [UserIsProfileOwnerOrReadOnly]

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -8,6 +8,7 @@ from .serializers import (SavedCompanySerializer, ProfileSerializer, ViewedCompa
                           ProfileSensitiveDataROSerializer, ProfileDetailSerializer)
 from .permissions import UserIsProfileOwnerOrReadOnly, IsAllowedToViewContacts
 
+
 class SavedCompaniesListCreate(ListCreateAPIView):
     """
     List of saved companies.
@@ -57,7 +58,7 @@ class ProfileList(ListCreateAPIView):
      include_all: bool.
     """
     serializer_class = ProfileSerializer
-    permission_classes = (IsAuthenticatedOrReadOnly, )
+    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def get_queryset(self):
         company_type = self.request.query_params.get("company_type")
@@ -85,7 +86,8 @@ class ProfileDetail(RetrieveUpdateDestroyAPIView):
     Retrieve or delete a profile instance.
     """
     queryset = Profile.objects.filter(is_deleted=False)
-    permission_classes = (UserIsProfileOwnerOrReadOnly, )
+    permission_classes = (UserIsProfileOwnerOrReadOnly,)
+    # TODO: add permission for GET contact request
 
     def get_serializer_class(self):
         get_contacts = self.request.query_params.get("with_contacts")
@@ -94,22 +96,11 @@ class ProfileDetail(RetrieveUpdateDestroyAPIView):
         else:
             return ProfileSerializer
 
-    def retrieve(self, request, *args, **kwargs):
-        instance = self.get_object()
-        if not request.user.is_authenticated and request.query_params.get("with_contacts"):
-            return Response(status=status.HTTP_401_UNAUTHORIZED)
-
-        if request.user.id == instance.person.id:
-            serializer = ProfileSerializer(instance)
-        else:
-            serializer = self.get_serializer(instance)
-
-        return Response(serializer.data)
+    # TODO: return for the owner full info
 
     def perform_destroy(self, instance):
         instance.is_deleted = True
         instance.save()
-
 
 
 class ViewedCompanyList(ListCreateAPIView):

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -102,8 +102,6 @@ class ProfileDetail(RetrieveUpdateDestroyAPIView):
         else:
             return ProfileSerializer
 
-    # TODO: return for the owner full info
-
     def perform_destroy(self, instance):
         instance.is_deleted = True
         instance.save()

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -96,7 +96,7 @@ class ProfileDetail(RetrieveUpdateDestroyAPIView):
             return Profile.objects.filter(profile_id=pk)
 
     def get_serializer_class(self):
-        get_contacts = self.request.query_params.get("get_contacts")
+        get_contacts = self.request.query_params.get("with_contacts")
         if self.request.method == 'GET':
             return ProfileSensitiveDataROSerializer if get_contacts else ProfileDetailSerializer
         else:
@@ -104,7 +104,7 @@ class ProfileDetail(RetrieveUpdateDestroyAPIView):
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
-        if not request.user.is_authenticated and request.query_params.get("get_contacts"):
+        if not request.user.is_authenticated and request.query_params.get("with_contacts"):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
 
         if request.user.id == instance.person.id:


### PR DESCRIPTION
## Summary of issue

Issue #175 
An authorized user is able to view the page of any Company with hidden contact data of the company.
Once the user presses the buttons "Show phone" or "Show email", the contact data should be shown and the data of the user who provided this action should be logged into the log journal.

## Summary of change

Two Profile serializers added: 
- `ProfileSensitiveDataROSerializer`: ReadOnly serializer, returns phone number and email
- `ProfileDetailSerializer`: ReadOnly serializer, returns detail data on profile without email and phone number

`ProfileDetailAPIView` altered:
- `get_serializer_class` method overriden
- all serializer calls in the methods adjusted
- `retrieve` method altered

upd: 
- `get_queryset` removed
- `get_serializer_class` returns proper serializer for the owner on GET request now
- `permission_classes` altered
- custom permission `UserIsProfileOwnerOrReadOnly` added
- `destroy` -> `perform_destroy`
- overriden `retrieve` and `update` removed

Three tests added and four are adjusted.

tests cleaned up a bit:
- setUpTestData moved to setUp in `test_crud_profiles`
- redundant code removed
- urls adjusted