### PR TITLE
#381 footer the appropriate pages privacy policy...

### DIFF
--- a/FrontEnd/public/index.html
+++ b/FrontEnd/public/index.html
@@ -6,7 +6,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="manifest" href="/manifest.json" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/FrontEnd/public/manifest.json
+++ b/FrontEnd/public/manifest.json
@@ -1,25 +1,9 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "name": "Forum",
   "icons": [
     {
       "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
+      "sizes": "32x32  16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    }
-  ],
-  "start_url": ".",
-  "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+    }]
 }

--- a/FrontEnd/public/manifest.json
+++ b/FrontEnd/public/manifest.json
@@ -3,7 +3,8 @@
   "icons": [
     {
       "src": "favicon.ico",
-      "sizes": "32x32  16x16",
+      "sizes": "32x32 16x16",
       "type": "image/x-icon"
-    }]
+    }
+  ]
 }

--- a/FrontEnd/src/components/CookiesPolicyPage/CookiesPolicyComponent.js
+++ b/FrontEnd/src/components/CookiesPolicyPage/CookiesPolicyComponent.js
@@ -1,25 +1,29 @@
 import css from './CookiesPolicyComponent.module.css';
-import {cookiesPolicy} from './Text';
+import { useEffect } from 'react';
+import { cookiesPolicy } from './Text';
 
 function CookiesPolicyComponent () {
+    useEffect(() => { window.scrollTo(0, 0); }, []);
     return (
-        <div>
+        <div className="block-cookies_policy block-size">
             <div className={css['root-container']}>
                 <div className={css['cookies-main']}>
                     <div className={css['title-container']}>
-                        <h1 className={css['title']}>Cookies Policy</h1>
+                        <h2 className={css['title']}>Cookies Policy</h2>
                         <p className={css['description']}>{cookiesPolicy.intro}</p>
                     </div>
                 </div>
             </div>
             <div className={css['cookies-section']}>
+                <ul>
                 <h4>Updated: {cookiesPolicy.updated}</h4>
                 {cookiesPolicy.sections.map((section) => (
-                    <p key={section.id}>
-                        <h2>{section.title}</h2>
+                    <li key={section.id}>
+                        <h3>{section.title}</h3>
                         <p>{section.content}</p>
-                    </p>
+                    </li>
                 ))}
+                </ul>
             </div>
         </div>
     );

--- a/FrontEnd/src/components/CookiesPolicyPage/CookiesPolicyComponent.js
+++ b/FrontEnd/src/components/CookiesPolicyPage/CookiesPolicyComponent.js
@@ -2,8 +2,11 @@ import css from './CookiesPolicyComponent.module.css';
 import { useEffect } from 'react';
 import { cookiesPolicy } from './Text';
 
-function CookiesPolicyComponent () {
-    useEffect(() => { window.scrollTo(0, 0); }, []);
+function CookiesPolicyComponent() {
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, []);
+
     return (
         <div className="block-cookies_policy block-size">
             <div className={css['root-container']}>
@@ -16,13 +19,13 @@ function CookiesPolicyComponent () {
             </div>
             <div className={css['cookies-section']}>
                 <ul>
-                <h4>Updated: {cookiesPolicy.updated}</h4>
-                {cookiesPolicy.sections.map((section) => (
-                    <li key={section.id}>
-                        <h3>{section.title}</h3>
-                        <p>{section.content}</p>
-                    </li>
-                ))}
+                    <h4>Updated: {cookiesPolicy.updated}</h4>
+                    {cookiesPolicy.sections.map((section) => (
+                        <li key={section.id}>
+                            <h3>{section.title}</h3>
+                            <p>{section.content}</p>
+                        </li>
+                    ))}
                 </ul>
             </div>
         </div>

--- a/FrontEnd/src/components/CookiesPolicyPage/CookiesPolicyComponent.module.css
+++ b/FrontEnd/src/components/CookiesPolicyPage/CookiesPolicyComponent.module.css
@@ -1,3 +1,9 @@
+.block-cookies_policy {
+    width: 100%;
+    max-width: 1500px;
+    margin: 0 auto;
+}
+
 .cookies-section {
     width: 1512px;
     text-align: center;
@@ -17,7 +23,7 @@
     justify-content: center;
     align-items: center;
     width: 100%;
-    min-height: 65vh;
+    min-height: 20vh;
     padding: 120px 100px 120px;
     color: #fff;
 }

--- a/FrontEnd/src/components/PrivacyPolicyPage/privacy/PrivacyPolicyComponent.css
+++ b/FrontEnd/src/components/PrivacyPolicyPage/privacy/PrivacyPolicyComponent.css
@@ -1,0 +1,5 @@
+.block-privacypolicy {
+    width: 100%;
+    max-width: 1500px;
+    margin: 0 auto;
+}

--- a/FrontEnd/src/components/PrivacyPolicyPage/privacy/PrivacyPolicyComponent.js
+++ b/FrontEnd/src/components/PrivacyPolicyPage/privacy/PrivacyPolicyComponent.js
@@ -1,23 +1,31 @@
 import './Text.css';
-import {privacyPolicy} from './Text';
+import './PrivacyPolicyComponent.css';
+import { privacyPolicy } from './Text';
+import { useEffect } from 'react';
+
 export function PrivacyPolicy() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
-    <div>
-      <div className="divider"/>
+    <div className="block-privacypolicy block-size">
+      <div className="divider" />
       <div className="privacy-text">
-        <h1>Privacy Policy</h1>
+        <h2>Privacy Policy</h2>
         <p>Updated: {privacyPolicy.updated}</p>
         <p>{privacyPolicy.intro}</p>
         <ul>
           {privacyPolicy.sections.map((section, index) => (
-            <p key={index}>
-              <h2>{section.title}</h2>
+            <li key={index}>
+              <h3>{section.title}</h3>
               <p>{section.content}</p>
-            </p>
+            </li>
           ))}
         </ul>
       </div>
     </div>
   );
 }
+
 export default PrivacyPolicy;

--- a/FrontEnd/src/components/ProfilePage/FormComponents/FormFields/CheckBoxField.module.css
+++ b/FrontEnd/src/components/ProfilePage/FormComponents/FormFields/CheckBoxField.module.css
@@ -55,7 +55,7 @@
 .form-control {
     display: flex;
     align-items: flex-start;
-    justify-content: start;
+    justify-content: flex-start;
     gap: 8px;
     color: var(--main-black-90, #292E32);
     font-feature-settings: 'calt' off;
@@ -69,7 +69,7 @@
 }
 
 .checkbox__input {
-    justify-content: start;
+    justify-content: flex-start;
     accent-color: #1F9A7C;
 }
 

--- a/FrontEnd/src/components/terms-and-conditions-app/terms_conditions/TermsAndConditionsComponent.css
+++ b/FrontEnd/src/components/terms-and-conditions-app/terms_conditions/TermsAndConditionsComponent.css
@@ -1,0 +1,5 @@
+.block-terms_and_conditions {
+    width: 100%;
+    max-width: 1500px;
+    margin: 0 auto;
+}

--- a/FrontEnd/src/components/terms-and-conditions-app/terms_conditions/TermsAndConditionsComponent.jsx
+++ b/FrontEnd/src/components/terms-and-conditions-app/terms_conditions/TermsAndConditionsComponent.jsx
@@ -4,7 +4,10 @@ import { useEffect } from 'react';
 import { termsConditions } from './Text';
 
 export function TermsAndConditions() {
-  useEffect(() => { window.scrollTo(0, 0); }, []);
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <div className="block-terms_and_conditions block-size">
       <div className="root-container">
@@ -31,4 +34,5 @@ export function TermsAndConditions() {
     </div>
   );
 }
+
 export default TermsAndConditions;

--- a/FrontEnd/src/components/terms-and-conditions-app/terms_conditions/TermsAndConditionsComponent.jsx
+++ b/FrontEnd/src/components/terms-and-conditions-app/terms_conditions/TermsAndConditionsComponent.jsx
@@ -1,13 +1,17 @@
 import './Text.css';
+import './TermsAndConditionsComponent.css';
+import { useEffect } from 'react';
 import { termsConditions } from './Text';
+
 export function TermsAndConditions() {
+  useEffect(() => { window.scrollTo(0, 0); }, []);
   return (
-    <div>
+    <div className="block-terms_and_conditions block-size">
       <div className="root-container">
         <div className="divider" />
         <div className="terms-conditions-main">
           <div className="title-container">
-            <h1 className="title">Terms & Conditions</h1>
+            <h2 className="title-terms_and_conditions">Terms & Conditions</h2>
             <p className="description">{termsConditions.intro}</p>
           </div>
         </div>
@@ -17,10 +21,10 @@ export function TermsAndConditions() {
           <p>Updated: {termsConditions.info.updated}</p>
           <p>{termsConditions.info.intro}</p>
           {termsConditions.sections.map((section, index) => (
-            <p key={index}>
-              <h2>{section.title}</h2>
+            <li key={index}>
+              <h3>{section.title}</h3>
               <p>{section.content}</p>
-            </p>
+            </li>
           ))}
         </ul>
       </div>

--- a/FrontEnd/src/components/terms-and-conditions-app/terms_conditions/Text.css
+++ b/FrontEnd/src/components/terms-and-conditions-app/terms_conditions/Text.css
@@ -18,7 +18,7 @@ h2 {
     justify-content: center;
     align-items: center;
     width: 100%;
-    min-height: 60vh;
+    min-height: 10vh;
     padding: 120px 100px 120px;
     color: #fff;
 }
@@ -27,7 +27,7 @@ h2 {
     position: relative;
 }
 
-.title {
+.title-terms_and_conditions {
     position: relative;
     text-align: start;
     max-width: 800px;
@@ -40,13 +40,13 @@ h2 {
     text-transform: uppercase;
 }
 
-.title::before {
+.title-terms_andconditions::before {
     position: absolute;
     bottom: 50%;
     left: -32px;
     z-index: 1;
     width: 166px;
-    height: 130%;
+    height: 100%;
     min-height: 160px;
     background-color: transparent;
     box-shadow: 0 19px 57px 0 rgba(0,0,0,.95);


### PR DESCRIPTION
[Footer] The appropriate pages (Privacy Policy, Terms & Conditions, Cookie Policy) are not opened on the top while moving through the links of the Footer 
      - add  useEffect window.scrollTo(0, 0)
Bug   replace:    
- start => flex-start
- index.html site.webmanifest => manifest.json  
