### PR TITLE
#image size bug on deploy

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -11,7 +11,6 @@ server {
     }
 
     location /media/ {
-        client_max_body_size 10M;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_pass http://api-dev:8000/media/;
@@ -20,7 +19,6 @@ server {
 
     # Django API
     location /api/ {
-        client_max_body_size 10M;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_pass http://api-dev:8000/api/;

--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    client_max_body_size 10;
+    client_max_body_size 10M;
 
     # React
     location / {

--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -11,6 +11,7 @@ server {
     }
 
     location /media/ {
+        client_max_body_size 10M;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_pass http://api-dev:8000/media/;
@@ -19,6 +20,7 @@ server {
 
     # Django API
     location /api/ {
+        client_max_body_size 10M;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_pass http://api-dev:8000/api/;

--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    client_max_body_size 10;
 
     # React
     location / {

--- a/images/tests/test_banner.py
+++ b/images/tests/test_banner.py
@@ -112,7 +112,7 @@ class TestBannerChange(APITestCase):
         self.assertEqual(
             {
                 "banner_image": [
-                    "Image size exceeds the maximum allowed (50MB)."
+                    "Image size exceeds the maximum allowed (5MB)."
                 ]
             },
             response.json(),

--- a/images/tests/test_logo.py
+++ b/images/tests/test_logo.py
@@ -107,6 +107,6 @@ class TestLogoChange(APITestCase):
         )
         self.assertEqual(400, response.status_code)
         self.assertEqual(
-            {"logo_image": ["Image size exceeds the maximum allowed (10MB)."]},
+            {"logo_image": ["Image size exceeds the maximum allowed (1MB)."]},
             response.json(),
         )

--- a/validation/validate_image.py
+++ b/validation/validate_image.py
@@ -21,10 +21,10 @@ def validate_image_format(image: Image):
 def validate_image_size(image_file):
     max_size = image_file.size
     if max_size > MAX_ALLOWED_BANNER_IMAGE_SIZE:
-        raise ValidationError("Image size exceeds the maximum allowed (50MB).")
+        raise ValidationError("Image size exceeds the maximum allowed (5MB).")
 
 
 def validate_logo_size(image_file):
     max_size = image_file.size
     if max_size > MAX_ALLOWED_LOGO_IMAGE_SIZE:
-        raise ValidationError("Image size exceeds the maximum allowed (10MB).")
+        raise ValidationError("Image size exceeds the maximum allowed (1MB).")


### PR DESCRIPTION
Increase nginx max size for files to 10M. It will show Error messages for files bigger than 5Mb (banner) and 1 Mb (logo). It will show 413 Error when file is bigger than 10 Mb. I can increase 10 Mb if we need it.
BE tests pass ok locally, but fail on GitHub. So it'll be my next task