### PR TITLE
#448 [Authentication] Email validation

### DIFF
--- a/forum/settings.py
+++ b/forum/settings.py
@@ -212,6 +212,7 @@ DJOSER = {
         "user_create_password_retype": "authentication.serializers.UserRegistrationSerializer",
         "user": "authentication.serializers.UserListSerializer",
         "current_user": "authentication.serializers.UserListSerializer",
+        "token_create": "authentication.serializers.CustomTokenCreateSerializer",
     },
 }
 

--- a/images/views.py
+++ b/images/views.py
@@ -4,7 +4,7 @@ from rest_framework.generics import (
 from rest_framework.parsers import MultiPartParser, FormParser
 
 from profiles.permissions import UserIsProfileOwnerOrReadOnly
-from profiles.models import Profile, Activity, Category
+from profiles.models import Profile
 from .serializers import BannerSerializer, LogoSerializer
 from utils.completeness_counter import completeness_count
 
@@ -13,7 +13,7 @@ class BannerRetrieveUpdate(RetrieveUpdateAPIView):
     permission_classes = (UserIsProfileOwnerOrReadOnly,)
     serializer_class = BannerSerializer
     parser_classes = (MultiPartParser, FormParser)
-    queryset = Profile.objects.all()
+    queryset = Profile.objects.filter(is_deleted=False, person__is_active=True)
 
     def perform_update(self, serializer):
         completeness_count(serializer)
@@ -23,7 +23,7 @@ class LogoRetrieveUpdate(RetrieveUpdateAPIView):
     permission_classes = (UserIsProfileOwnerOrReadOnly,)
     serializer_class = LogoSerializer
     parser_classes = (MultiPartParser, FormParser)
-    queryset = Profile.objects.all()
+    queryset = Profile.objects.filter(is_deleted=False, person__is_active=True)
 
     def perform_update(self, serializer):
         completeness_count(serializer)

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -124,7 +124,9 @@ class ProfileList(ListCreateAPIView):
 
     def get_queryset(self):
         user_id = self.request.query_params.get("userid")
-        queryset = Profile.objects.filter(is_deleted=False, person__is_active=True).order_by("id")
+        queryset = Profile.objects.filter(
+            is_deleted=False, person__is_active=True
+        ).order_by("id")
         if user_id:
             try:
                 return queryset.filter(person_id=user_id)

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -124,7 +124,7 @@ class ProfileList(ListCreateAPIView):
 
     def get_queryset(self):
         user_id = self.request.query_params.get("userid")
-        queryset = Profile.objects.filter(is_deleted=False).order_by("id")
+        queryset = Profile.objects.filter(is_deleted=False, person__is_active=True).order_by("id")
         if user_id:
             try:
                 return queryset.filter(person_id=user_id)
@@ -148,7 +148,7 @@ class ProfileDetail(RetrieveUpdateDestroyAPIView):
         If user is authenticated, he can get sensitive data via query param 'with_contacts'.
     """
 
-    queryset = Profile.objects.filter(is_deleted=False)
+    queryset = Profile.objects.filter(is_deleted=False, person__is_active=True)
     permission_classes = [UserIsProfileOwnerOrReadOnly]
 
     def get_serializer_context(self):

--- a/search/views.py
+++ b/search/views.py
@@ -8,7 +8,7 @@ from search.filters import CompanyFilter
 
 
 class SearchCompanyView(ListAPIView):
-    queryset = Profile.objects.all()
+    queryset = Profile.objects.filter(is_deleted=False, person__is_active=True)
     serializer_class = CompanySerializers
     filter_backends = [
         django_filters.rest_framework.DjangoFilterBackend,


### PR DESCRIPTION
Previously, the email was case-sensitive during registration and login. 
This has been fixed - the email is now validated and stored in db in lowercase during sign-up (validation has been updated), login is carried out with the email in lowercase (TokenCreateSerializer has been overridden for that purpose).
Extra fixes - queryset filter for profiles has been clarified. Only profiles that are not deleted and with active users are returned. 