### PR TITLE
#493 Django Debug Toolbar added to the project

### DIFF
--- a/.github/workflows/tests_be.yml
+++ b/.github/workflows/tests_be.yml
@@ -2,7 +2,7 @@ name: Testing BE
 on: pull_request
 
 env:
-  DEBUG: ''
+  DEBUG: False
   SECRET_KEY: django-insecure-8p_=_(i8$#=t_n26md(d7=gpc%5sss!4-1a0cp(lir3-0x^$8%
   PG_DB: db
   PG_USER: postgres

--- a/.github/workflows/tests_be.yml
+++ b/.github/workflows/tests_be.yml
@@ -2,6 +2,7 @@ name: Testing BE
 on: pull_request
 
 env:
+  DEBUG: ''
   SECRET_KEY: django-insecure-8p_=_(i8$#=t_n26md(d7=gpc%5sss!4-1a0cp(lir3-0x^$8%
   PG_DB: db
   PG_USER: postgres

--- a/forum/settings.py
+++ b/forum/settings.py
@@ -27,7 +27,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = config("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config("DEBUG")
 
 ALLOWED_HOSTS = [
     "localhost",
@@ -36,15 +36,6 @@ ALLOWED_HOSTS = [
     "0.0.0.0",
     config("ALLOWED_ENV_HOST"),
 ]
-
-if DEBUG:
-    import socket
-
-    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-    INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + [
-        "127.0.0.1",
-        "10.0.2.2",
-    ]
 
 # Application definition
 
@@ -230,3 +221,12 @@ DJOSER = {
 
 DELAY_FOR_LOGIN = 600  # delay time for login in seconds
 ATTEMPTS_FOR_LOGIN = 10  # attempts for login during delay for login
+
+
+def show_toolbar(request):
+    return DEBUG
+
+
+DEBUG_TOOLBAR_CONFIG = {
+    "SHOW_TOOLBAR_CALLBACK": show_toolbar,
+}

--- a/forum/settings.py
+++ b/forum/settings.py
@@ -37,6 +37,15 @@ ALLOWED_HOSTS = [
     config("ALLOWED_ENV_HOST"),
 ]
 
+if DEBUG:
+    import socket
+
+    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+    INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + [
+        "127.0.0.1",
+        "10.0.2.2",
+    ]
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -50,6 +59,7 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "django_filters",
     "djoser",
+    "debug_toolbar",
     "authentication",
     "profiles",
     "administration",
@@ -60,6 +70,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -69,6 +80,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     # "ratelimitbackend.middleware.RateLimitMiddleware",
 ]
+
 CORS_ALLOW_CREDENTIALS = True
 
 CORS_ALLOW_ALL_ORIGINS = False

--- a/forum/urls.py
+++ b/forum/urls.py
@@ -18,6 +18,7 @@ from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from django.conf import settings
 from django.conf.urls.static import static
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 urlpatterns = [
     path("api/", include("authentication.urls", namespace="authentication")),
@@ -36,3 +37,5 @@ urlpatterns = [
     ),
     path("__debug__/", include("debug_toolbar.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+urlpatterns += staticfiles_urlpatterns()

--- a/forum/urls.py
+++ b/forum/urls.py
@@ -34,4 +34,5 @@ urlpatterns = [
         SpectacularSwaggerView.as_view(url_name="schema"),
         name="schema_docs",
     ),
+    path("__debug__/", include("debug_toolbar.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ toml==0.10.2
 black==23.9.1
 drf-spectacular==0.26.5
 ratelimit==2.2.1
-
+django-debug-toolbar==4.3.0
 


### PR DESCRIPTION
Django Debug Toolbar has been added to the project.

But I have an issue.
It runs well locally, without containers. 
But when I build all the containers provided by the project, I have to add to the project urls.py:
 
"from django.contrib.staticfiles.urls import staticfiles_urlpatterns
urlpatterns += staticfiles_urlpatterns()"

so that Debug Toolbar and Browsable API work correctly (otherwise static files of drf and debug toolbar are not accessible).

I'm not sure if this is my local problem or if I have to add that to the project code.