### PR TITLE
#505 [FE] Fix profiles order in lists

### DIFF
--- a/FrontEnd/src/components/SearchPage/Search.jsx
+++ b/FrontEnd/src/components/SearchPage/Search.jsx
@@ -28,7 +28,7 @@ export function Search({ isAuthorized }) {
   };
 
   const { data: companylist, error } = useSWR(
-    `${servedAddress}/api/search/?name=${searchTerm}`,
+    `${servedAddress}/api/search/?name=${searchTerm}&ordering=name`,
     fetcher
   );
 

--- a/FrontEnd/src/components/landing-page/companies/Companies.jsx
+++ b/FrontEnd/src/components/landing-page/companies/Companies.jsx
@@ -17,7 +17,7 @@ const MainCompanies = ({ isAuthorized }) => {
   };
 
   const { data: companylist } = useSWR(
-    `${baseUrl}/api/profiles/?new_members=-completeness,-created_at`,
+    `${baseUrl}/api/profiles/?ordering=-completeness,-created_at`,
     fetcher
   );
 

--- a/FrontEnd/src/components/profileList/ProfileListPage.jsx
+++ b/FrontEnd/src/components/profileList/ProfileListPage.jsx
@@ -33,13 +33,13 @@ export default function ProfileListPage({ isAuthorized }) {
     setCurrentPage(1);
   }, [filter]);
 
-  const urlForAll = `${process.env.REACT_APP_BASE_API_URL}/api/profiles/?${profileFilter}&page=${currentPage}`;
+  const urlForAll = `${process.env.REACT_APP_BASE_API_URL}/api/profiles/?${profileFilter}&ordering=name&page=${currentPage}`;
 
   const urlForSaved = `${
     process.env.REACT_APP_BASE_API_URL
   }/api/profiles/?${profileFilter}${
     filterSaved ? '&is_saved=True' : ''
-  }&page=${currentPage}`;
+  }&ordering=-saved_at&page=${currentPage}`;
 
   async function fetcher(url) {
     return axios.get(url)

--- a/FrontEnd/src/tests/MainCompanies.test.js
+++ b/FrontEnd/src/tests/MainCompanies.test.js
@@ -100,7 +100,7 @@ describe('MainCompanies component unit tests', () => {
         </MemoryRouter>
       );
       expect(axios.get).toHaveBeenCalledWith(
-        'http://localhost:8000/api/profiles/?new_members=-completeness,-created_at'
+        'http://localhost:8000/api/profiles/?ordering=-completeness,-created_at'
       );
       const divElement = screen.getByText(/Нові учасники/i, { exact: false });
       const onenameElement = screen.getByText(/saleonline/i, {


### PR DESCRIPTION
The profiles ordering has been corrected according to the requirements:
- list of companies/startups - in alphabetical order;
- list of saved companies - in chronological order (newest first);
- search results -  in alphabetical order.
