### PR TITLE
#568 Fix bug with optional unique char fields

### DIFF
--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -257,6 +257,14 @@ class ProfileOwnerDetailEditSerializer(serializers.ModelSerializer):
             )
         return data
 
+    # set optional unique fields to None if they are empty
+    def to_internal_value(self, data):
+        fields_to_check = ["official_name", "edrpou", "rnokpp"]
+        for field in fields_to_check:
+            if data.get(field) == "":
+                data[field] = None
+        return super().to_internal_value(data)
+
 
 class ProfileDeleteSerializer(serializers.Serializer):
     password = serializers.CharField(write_only=True, required=True)

--- a/profiles/tests/test_crud_profile.py
+++ b/profiles/tests/test_crud_profile.py
@@ -532,6 +532,83 @@ class TestProfileDetailAPIView(APITestCase):
         )
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
+    def test_partial_update_profile_official_name_empty_value(self):
+        self.client.force_authenticate(self.user)
+
+        response = self.client.patch(
+            path="/api/profiles/{profile_id}".format(
+                profile_id=self.profile.id
+            ),
+            data={"official_name": ""},
+            format="json",
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertIsNone(response.data.get("official_name"))
+
+    def test_partial_update_profile_edrpou_empty_value(self):
+        self.client.force_authenticate(self.user)
+
+        response = self.client.patch(
+            path="/api/profiles/{profile_id}".format(
+                profile_id=self.profile.id
+            ),
+            data={"edrpou": ""},
+            format="json",
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertIsNone(response.data.get("edrpou"))
+
+    def test_partial_update_profile_rnokpp_empty_value(self):
+        self.client.force_authenticate(self.user)
+
+        response = self.client.patch(
+            path="/api/profiles/{profile_id}".format(
+                profile_id=self.profile.id
+            ),
+            data={"rnokpp": ""},
+            format="json",
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertIsNone(response.data.get("rnokpp"))
+
+    # updating fields when another instance with empty fields already exists in db
+    def test_partial_update_profile_fields_with_empty_values(
+        self,
+    ):
+        ProfileStartupFactory.create(
+            official_name=None,
+            edrpou=None,
+        )
+        self.client.force_authenticate(self.user)
+
+        response = self.client.patch(
+            path="/api/profiles/{profile_id}".format(
+                profile_id=self.profile.id
+            ),
+            data={"official_name": "", "edrpou": ""},
+            format="json",
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+        response = self.client.get(path="/api/profiles/")
+        self.assertEqual(2, response.data["total_items"])
+        self.assertTrue(
+            all(
+                [
+                    item.get("official_name") is None
+                    for item in response.data["results"]
+                ]
+            )
+        )
+        self.assertTrue(
+            all(
+                [
+                    item.get("edrpou") is None
+                    for item in response.data["results"]
+                ]
+            )
+        )
+
     def test_partial_update_profile_is_fop_with_edrpou(self):
         self.client.force_authenticate(self.user)
 
@@ -559,6 +636,7 @@ class TestProfileDetailAPIView(APITestCase):
                 profile_id=self.profile.id
             ),
             data={"edrpou": "", "rnokpp": "1111111118"},
+            format="json",
         )
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         self.assertEqual(
@@ -578,6 +656,7 @@ class TestProfileDetailAPIView(APITestCase):
                 profile_id=self.profile.id
             ),
             data={"edrpou": "", "is_fop": True, "rnokpp": "1234567899"},
+            format="json",
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("1234567899", response.data.get("rnokpp"))
@@ -591,6 +670,7 @@ class TestProfileDetailAPIView(APITestCase):
                 profile_id=self.profile.id
             ),
             data={"edrpou": "", "is_fop": True, "rnokpp": "12345678"},
+            format="json",
         )
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         self.assertEqual(
@@ -608,6 +688,7 @@ class TestProfileDetailAPIView(APITestCase):
                 profile_id=self.profile.id
             ),
             data={"edrpou": "", "is_fop": True, "rnokpp": "1234567889"},
+            format="json",
         )
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         self.assertEqual(


### PR DESCRIPTION
There was no possibility to save multiple objects with blank values for optional unique fields. This was fixed by overriding to_internal_value method. An optional unique field is set to None if it is an empty string. 