### PR TITLE
#593 [FE] Add pages to query params for profile lists

### DIFF
--- a/FrontEnd/src/components/HeaderFooter/header/navbar/SearchBox.jsx
+++ b/FrontEnd/src/components/HeaderFooter/header/navbar/SearchBox.jsx
@@ -12,6 +12,7 @@ function SearchBox() {
   const handleSearch = (searchTerm, searchPage) => {
     if (searchTerm.trim() !== '') {
       navigate(`/${searchPage}/?name=${searchTerm}`);
+      setSearchTerm('');
     }
   };
   return (

--- a/FrontEnd/src/components/SearchPage/Search.jsx
+++ b/FrontEnd/src/components/SearchPage/Search.jsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import BreadCrumbs from '../BreadCrumbs/BreadCrumbs';
 import SearchResults from './search_field/SearchResults';
 import frame42 from './img/frame42.png';
@@ -17,8 +17,10 @@ export function Search({ isAuthorized }) {
   const [searchPerformed, setSearchPerformed] = useState(false);
 
   const location = useLocation();
+  const navigate = useNavigate();
   const searchParams = new URLSearchParams(location.search);
   const searchTerm = searchParams.get('name');
+  const pageNumber = Number(searchParams.get('page')) || 1;
   const servedAddress = process.env.REACT_APP_BASE_API_URL;
   const searchUrl = 'search';
 
@@ -48,7 +50,11 @@ export function Search({ isAuthorized }) {
     }
   }, [searchTerm, servedAddress, searchUrl, companylist]);
 
-  const [currentPage, setCurrentPage] = useState(1);
+  useEffect(() => {
+    setCurrentPage(pageNumber);
+  }, [pageNumber]);
+
+  const [currentPage, setCurrentPage] = useState(pageNumber);
   const totalItems = searchResults.length;
   const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
 
@@ -58,6 +64,8 @@ export function Search({ isAuthorized }) {
 
   const handlePageChange = (newPage) => {
     setCurrentPage(newPage);
+    searchParams.set('page', newPage);
+    navigate(`?${searchParams.toString()}`);
   };
 
   return (
@@ -163,10 +171,6 @@ export function Search({ isAuthorized }) {
 }
 
 export default Search;
-
-Search.propTypes = {
-  isAuthorized: PropTypes.bool,
-};
 
 Search.propTypes = {
   isAuthorized: PropTypes.bool,

--- a/FrontEnd/src/components/profileList/ProfileListPage.jsx
+++ b/FrontEnd/src/components/profileList/ProfileListPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import axios from 'axios';
 
 import { Radio } from 'antd';
@@ -12,11 +12,14 @@ import ProfileList from './ProfileList';
 import css from './ProfileListPage.module.css';
 
 export default function ProfileListPage({ isAuthorized }) {
+  const location = useLocation();
+  const navigate = useNavigate();
   const { filter } = useParams();
+  const queryParams = new URLSearchParams(location.search);
+  const pageNumber = Number(queryParams.get('page')) || 1;
 
   const [filterSaved, setFilterSaved] = useState(false);
-  const [currentPage, setCurrentPage] = useState(1);
-
+  const [currentPage, setCurrentPage] = useState(pageNumber);
   const [profileFilter, setProfileFilter] = useState('');
 
   useEffect(() => {
@@ -31,8 +34,18 @@ export default function ProfileListPage({ isAuthorized }) {
     };
     setProfileFilter(FILTER_MAP[filter]);
     setFilterSaved(false);
-    setCurrentPage(1);
-  }, [filter]);
+    setCurrentPage(pageNumber);
+  }, [filter, pageNumber]);
+
+  const updateQueryParams = (newPage) => {
+    queryParams.set('page', newPage);
+    navigate(`?${queryParams.toString()}`);
+  };
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page);
+    updateQueryParams(page);
+  };
 
   const urlForAll = `${process.env.REACT_APP_BASE_API_URL}/api/profiles/?${profileFilter}&ordering=name&page=${currentPage}`;
 
@@ -87,7 +100,7 @@ export default function ProfileListPage({ isAuthorized }) {
               isAuthorized={isAuthorized}
               isLoading={isLoading}
               data={fetchedProfiles}
-              paginationFunc={setCurrentPage}
+              paginationFunc={handlePageChange}
               current={currentPage}
             />
           )}


### PR DESCRIPTION

Pages have been added to the query parameters for profile lists and search results. 
Now, users can navigate using browser navigation, and the corresponding page is displayed. Previously, users were always redirected to the first page when pressing the go back arrow, regardless of their previous page.