### PR TITLE
#669 Update Workflows

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,5 +6,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: psf/black@stable

--- a/.github/workflows/db_deploy.yaml
+++ b/.github/workflows/db_deploy.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Docker compouse DOWN old containers
         run:  docker compose -f docker-compose.db.yml down -v
       - name: Docker compouse UP new containers

--- a/.github/workflows/django_cd_dev.yml
+++ b/.github/workflows/django_cd_dev.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker compouse DOWN old Django container and frontend container (+internal nginx)
         run:  docker compose -f docker-compose.dev.yml down -v

--- a/.github/workflows/django_cd_prod.yml
+++ b/.github/workflows/django_cd_prod.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker compouse DOWN old Django container
         run: docker compose -f docker-compose.dev.yml down -v

--- a/.github/workflows/django_ci.yml
+++ b/.github/workflows/django_ci.yml
@@ -43,9 +43,9 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest # on which machine to run
     steps: # list of steps
       - name: Install NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
 
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/nginx_deploy.yaml
+++ b/.github/workflows/nginx_deploy.yaml
@@ -7,7 +7,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Docker compouse DOWN old containers
         run: docker compose -f docker-compose.nginx.yml down -v
       - name: Docker compouse UP new containers

--- a/.github/workflows/pgadmin_deploy.yaml
+++ b/.github/workflows/pgadmin_deploy.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Docker compouse UP new containers
         run: docker compose -f docker-compose.db.yml up pgadmin -d --build
       - name: Clean up old docker resources

--- a/.github/workflows/tests_be.yml
+++ b/.github/workflows/tests_be.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: install ./BackEnd/requirements.txt
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests_be.yml
+++ b/.github/workflows/tests_be.yml
@@ -43,10 +43,10 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-verion: 3.10
+          python-version: 3.10
       - name: install ./BackEnd/requirements.txt
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests_fe.yml
+++ b/.github/workflows/tests_fe.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest # on which machine to run
     steps: # list of steps
       - name: Install NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
 
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
The problem occurred during the last workflow:

The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3.
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Necessary updates have been made.