### PR TITLE
#677 Update new password field error handling

### DIFF
--- a/FrontEnd/src/components/ProfilePage/FormComponents/ChangePassword.jsx
+++ b/FrontEnd/src/components/ProfilePage/FormComponents/ChangePassword.jsx
@@ -47,11 +47,17 @@ export default function ChangePassword(props) {
         }
       )
       .then(() => toast.success('Пароль успішно змінено'))
-      .catch(() =>
-        toast.error(
-          'Виникла помилка. Можливо, вказано невірний поточний пароль'
-        )
-      );
+      .catch((error) => {
+        if (error.response && error.response.data && error.response.data['new_password']) {
+          const newPasswordError = error.response.data['new_password'][0];
+          if (newPasswordError === 'This password is too common.') {
+          toast.error('Пароль занадто поширений. Створіть інший пароль.');
+        } else if (newPasswordError.startsWith('The password is too similar to the')) {
+          toast.error('Пароль подібний на іншу персональну інформацію облікового запису. Створіть інший пароль.');
+        }
+      } else
+        toast.error('Виникла помилка. Можливо, вказано невірний поточний пароль');
+      });
     reset();
   };
 


### PR DESCRIPTION
new_password field error handling has been updated.
Appropriate messages are returned on UI for password validation errors on the backend:
- "Пароль занадто поширений. Створіть інший пароль." for "This password is too common". 
- "Пароль подібний на іншу персональну інформацію облікового запису. Створіть інший пароль." for "The password is too similar to the ..."
