### PR TITLE
#724 [BE] [Profile Moderation] Incorporate reject logic

### DIFF
--- a/BackEnd/authentication/serializers.py
+++ b/BackEnd/authentication/serializers.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from django.contrib.auth import authenticate, get_user_model
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.conf import settings as django_settings
 from djoser.conf import settings as djoser_settings
@@ -19,6 +19,7 @@ from validation.validate_password import (
     validate_password_long,
     validate_password_include_symbols,
 )
+from validation.validate_profile import validate_profile
 
 User = get_user_model()
 
@@ -105,6 +106,11 @@ class UserListSerializer(UserSerializer):
 
 class CustomTokenCreateSerializer(TokenCreateSerializer):
     def validate(self, attrs):
+        try:
+            validate_profile(attrs.get("email"))
+        except ValidationError as error:
+            raise serializers.ValidationError(error.message)
+
         try:
             return self.validate_for_rate(attrs)
         except RateLimitException:

--- a/BackEnd/profiles/serializers.py
+++ b/BackEnd/profiles/serializers.py
@@ -388,15 +388,15 @@ class ProfileModerationSerializer(serializers.Serializer):
         error_messages={"invalid_choice": "Action is not allowed"},
         write_only=True,
     )
-    banner_approved = ProfileImageField(write_only=True)
-    logo_approved = ProfileImageField(write_only=True)
+    banner = ProfileImageField(write_only=True)
+    logo = ProfileImageField(write_only=True)
     status_updated_at = serializers.DateTimeField(read_only=True)
     status = serializers.CharField(read_only=True)
 
-    def validate(self, value):
+    def validate(self, attrs):
         profile = self.instance
-        banner = value.get("banner_approved")
-        logo = value.get("logo_approved")
+        banner = attrs.get("banner")
+        logo = attrs.get("logo")
         if profile.status != profile.PENDING:
             raise serializers.ValidationError(
                 "The change approval request has been processed. URL is outdated"
@@ -408,21 +408,21 @@ class ProfileModerationSerializer(serializers.Serializer):
                 raise serializers.ValidationError(
                     "There is a new request for moderation. URL is outdated"
                 )
-        return value
+        return attrs
 
     def update(self, instance, validated_data):
         action = validated_data.get("action")
-        banner_approved = validated_data.get("banner_approved")
-        logo_approved = validated_data.get("logo_approved")
+        banner = validated_data.get("banner")
+        logo = validated_data.get("logo")
 
         if action == ModerationAction.approve:
-            if banner_approved:
+            if banner:
                 instance.banner.is_approved = True
-                instance.banner_approved = banner_approved
+                instance.banner_approved = banner
                 instance.banner.save()
-            if logo_approved:
+            if logo:
                 instance.logo.is_approved = True
-                instance.logo_approved = logo_approved
+                instance.logo_approved = logo
                 instance.logo.save()
             instance.status = instance.APPROVED
 

--- a/BackEnd/profiles/serializers.py
+++ b/BackEnd/profiles/serializers.py
@@ -438,4 +438,3 @@ class ProfileModerationSerializer(serializers.Serializer):
         instance.status_updated_at = now()
         instance.save()
         return instance
-

--- a/BackEnd/profiles/serializers.py
+++ b/BackEnd/profiles/serializers.py
@@ -414,6 +414,7 @@ class ProfileModerationSerializer(serializers.Serializer):
         action = validated_data.get("action")
         banner_approved = validated_data.get("banner_approved")
         logo_approved = validated_data.get("logo_approved")
+
         if action == ModerationAction.approve:
             if banner_approved:
                 instance.banner.is_approved = True
@@ -424,8 +425,17 @@ class ProfileModerationSerializer(serializers.Serializer):
                 instance.logo_approved = logo_approved
                 instance.logo.save()
             instance.status = instance.APPROVED
-            instance.status_updated_at = now()
-            instance.save()
-            return instance
+
+        elif action == ModerationAction.reject:
+            instance.status = instance.BLOCKED
+            instance.is_deleted = True
+            instance.person.is_active = False
+            instance.person.save()
+
         else:
             raise serializers.ValidationError("Invalid action provided.")
+
+        instance.status_updated_at = now()
+        instance.save()
+        return instance
+

--- a/BackEnd/profiles/templates/profiles/email_template.html
+++ b/BackEnd/profiles/templates/profiles/email_template.html
@@ -61,7 +61,7 @@
         {% endif %}
         <div style="margin: 20px 0;">
             <a href="{{protocol}}://{{ domain }}/{{ approve_url }}" class="button button-approve">ЗАТВЕРДИТИ</a>
-            <a href="#" class="button button-reject">СКАСУВАТИ</a>
+            <a href="{{protocol}}://{{ domain }}/{{ reject_url }}" class="button button-reject">СКАСУВАТИ</a>
         </div>
         <p><b>Примітка:</b> <i>запит буде автоматично затверджений через {{ moderation_time }}</i></p>
         <p>З повагою,</p>

--- a/BackEnd/profiles/views.py
+++ b/BackEnd/profiles/views.py
@@ -272,7 +272,7 @@ class RegionDetail(RetrieveUpdateDestroyAPIView):
 
 class ProfileModeration(UpdateAPIView):
     serializer_class = ProfileModerationSerializer
-    queryset = Profile.objects.active_only()
+    queryset = Profile.objects.all()
     lookup_url_kwarg = "profile_id"
 
     def get_object(self):

--- a/BackEnd/utils/moderation/send_email.py
+++ b/BackEnd/utils/moderation/send_email.py
@@ -35,7 +35,12 @@ def generate_profile_moderation_url(profile_id, banner, logo, action):
         query_params["logo"] = logo.uuid
     params = urlencode(query_params)
     id = encode_id(profile_id)
-    return f"moderation/{id}/{action}/?{params}"
+    url = (
+        f"moderation/{id}/{action}/?{params}"
+        if params
+        else f"moderation/{id}/{action}/"
+    )
+    return url
 
 
 def attach_image(email, image, content_id):
@@ -69,7 +74,9 @@ def send_moderation_email(profile):
             "approve_url": generate_profile_moderation_url(
                 profile.id, banner, logo, "approve"
             ),
-            "reject_url": None,
+            "reject_url": generate_profile_moderation_url(
+                profile.id, None, None, "reject"
+            ),
         }
 
         email_body = render_to_string("profiles/email_template.html", context)

--- a/BackEnd/utils/moderation/send_email.py
+++ b/BackEnd/utils/moderation/send_email.py
@@ -35,12 +35,7 @@ def generate_profile_moderation_url(profile_id, banner, logo, action):
         query_params["logo"] = logo.uuid
     params = urlencode(query_params)
     id = encode_id(profile_id)
-    url = (
-        f"moderation/{id}/{action}/?{params}"
-        if params
-        else f"moderation/{id}/{action}/"
-    )
-    return url
+    return f"moderation/{id}/{action}/?{params}"
 
 
 def attach_image(email, image, content_id):
@@ -75,7 +70,7 @@ def send_moderation_email(profile):
                 profile.id, banner, logo, "approve"
             ),
             "reject_url": generate_profile_moderation_url(
-                profile.id, None, None, "reject"
+                profile.id, banner, logo, "reject"
             ),
         }
 

--- a/BackEnd/validation/validate_profile.py
+++ b/BackEnd/validation/validate_profile.py
@@ -1,0 +1,17 @@
+from django.core.exceptions import ValidationError
+from django.contrib.auth import get_user_model
+
+from profiles.models import Profile
+
+User = get_user_model()
+
+
+def validate_profile(user_email):
+    user = User.objects.filter(email=user_email, is_active=False).first()
+    if (
+        user
+        and Profile.objects.filter(
+            person=user, is_deleted=True, status=Profile.BLOCKED
+        ).first()
+    ):
+        raise ValidationError("Profile has been blocked.")


### PR DESCRIPTION
The logic for rejecting moderation request has been implemented.
Profile status is changed to 'blocked', profile is marked as deleted, user is marked as inactive. As a result, profile is no longer shown on the site, user cannot log in, and not allowed to sign up with the same email.