### PR TITLE
#733 [FE] [Moderation] Adjust UI according to 'Reject' logic

### DIFF
--- a/FrontEnd/src/components/authorization/LoginPage.jsx
+++ b/FrontEnd/src/components/authorization/LoginPage.jsx
@@ -75,6 +75,7 @@ const LoginContent = () => {
   useEffect(() => {
     clearErrors('unspecifiedError');
     clearErrors('rateError');
+    clearErrors('blockedUserError');
   }, [getValues('email'), getValues('password'), clearErrors]);
 
   const disabled = !isValid || (isRunning && minutes < 10);
@@ -113,7 +114,7 @@ const LoginContent = () => {
             message: errorMessageTemplates.rateError,
           });
         } else if (resp == 'Profile has been blocked.') {
-            setError('rateError', {
+            setError('blockedUserError', {
               type: 'manual',
               message: errorMessageTemplates.blockedUserError,
           });

--- a/FrontEnd/src/components/authorization/LoginPage.jsx
+++ b/FrontEnd/src/components/authorization/LoginPage.jsx
@@ -30,6 +30,7 @@ const LoginContent = () => {
     email: 'Електронна пошта не відповідає вимогам',
     unspecifiedError: 'Електронна пошта чи пароль вказані некоректно',
     rateError: 'Небезпечні дії на сторінці. Сторінка заблокована на 10 хвилин',
+    blockedUserError: 'Профіль компанії було заблоковано внаслідок розміщення неприйнятного контенту',
   };
 
   const {
@@ -58,6 +59,8 @@ const LoginContent = () => {
       errorMessage = errors.unspecifiedError.message;
     } else if (errors.rateError?.message) {
       errorMessage = errors.rateError.message;
+    } else if (errors.blockedUserError?.message) {
+      errorMessage = errors.blockedUserError.message;
     }
 
     errorMessage && toast.error(errorMessage);
@@ -66,6 +69,7 @@ const LoginContent = () => {
     errors.password?.message,
     errors.unspecifiedError?.message,
     errors.rateError?.message,
+    errors.blockedUserError?.message,
   ]);
 
   useEffect(() => {
@@ -107,6 +111,11 @@ const LoginContent = () => {
           setError('rateError', {
             type: 'manual',
             message: errorMessageTemplates.rateError,
+          });
+        } else if (resp == 'Profile has been blocked.') {
+            setError('rateError', {
+              type: 'manual',
+              message: errorMessageTemplates.blockedUserError,
           });
         }
       }

--- a/FrontEnd/src/components/moderation/ModerationModal.jsx
+++ b/FrontEnd/src/components/moderation/ModerationModal.jsx
@@ -16,8 +16,8 @@ export function ModerationModal() {
 
   const data = {
     action,
-    ...(banner && { banner_approved: banner }),
-    ...(logo && { logo_approved: logo }),
+    ...(banner && { banner: banner }),
+    ...(logo && { logo: logo }),
   };
 
   const errorMessages = {

--- a/FrontEnd/src/hooks/useProfile.js
+++ b/FrontEnd/src/hooks/useProfile.js
@@ -19,7 +19,7 @@ export default function useProfile() {
       })
       .then(res => res.data)
       .catch((error) => {
-        if (error.response && error.response.status === 401 || error.response && error.response.status === 404) {
+        if (error.response && (error.response.status === 401 || error.response.status === 404)) {
           logout();
         }
         console.error('An error occurred while fetching the data.', error);

--- a/FrontEnd/src/hooks/useProfile.js
+++ b/FrontEnd/src/hooks/useProfile.js
@@ -19,7 +19,7 @@ export default function useProfile() {
       })
       .then(res => res.data)
       .catch((error) => {
-        if (error.response && error.response.status === 401) {
+        if (error.response && error.response.status === 401 || error.response && error.response.status === 404) {
           logout();
         }
         console.error('An error occurred while fetching the data.', error);


### PR DESCRIPTION
The message 'Зміни успішно скасовано. Профіль компанії заблоковано' is displayed when moderator reject the moderation request. 
If the user is authorized at that moment the profile is blocked, he will be logged out.
When a user with a blocked profile tries to log in, he sees the toast message 'Профіль компанії було заблоковано внаслідок розміщення неприйнятного контенту' and is not allowed to log in.

![image](https://github.com/user-attachments/assets/1500f5d7-2f46-4473-824e-39bada60ce2c)

![image](https://github.com/user-attachments/assets/f3864d17-5fe4-40e8-9633-db5d5b329608)
