### PR TITLE
#726 v2 handle moderation request for removed content

### DIFF
--- a/BackEnd/profiles/models.py
+++ b/BackEnd/profiles/models.py
@@ -24,7 +24,6 @@ class Region(models.Model):
 
 
 class Profile(models.Model):
-
     UNDEFINED = "undefined"
     PENDING = "pending"
     BLOCKED = "blocked"

--- a/BackEnd/profiles/serializers.py
+++ b/BackEnd/profiles/serializers.py
@@ -231,8 +231,8 @@ class ProfileOwnerDetailViewSerializer(serializers.ModelSerializer):
 
 class ProfileOwnerDetailEditSerializer(serializers.ModelSerializer):
     email = serializers.ReadOnlyField(source="person.email")
-    banner = ProfileImageField()
-    logo = ProfileImageField()
+    banner = ProfileImageField(allow_null=True)
+    logo = ProfileImageField(allow_null=True)
 
     class Meta:
         model = Profile

--- a/BackEnd/profiles/serializers.py
+++ b/BackEnd/profiles/serializers.py
@@ -231,8 +231,8 @@ class ProfileOwnerDetailViewSerializer(serializers.ModelSerializer):
 
 class ProfileOwnerDetailEditSerializer(serializers.ModelSerializer):
     email = serializers.ReadOnlyField(source="person.email")
-    banner = ProfileImageField(allow_null=True)
-    logo = ProfileImageField(allow_null=True)
+    banner = ProfileImageField()
+    logo = ProfileImageField()
 
     class Meta:
         model = Profile

--- a/BackEnd/profiles/templates/profiles/email_template.html
+++ b/BackEnd/profiles/templates/profiles/email_template.html
@@ -44,8 +44,12 @@
     <div>
         <img src="{{protocol}}://178.212.110.52/craftMerge-logo.png" alt="CRAFTMERGE"/>
         <p>Доброго дня,</p>
+        {% if not banner_logo_deleted %}
         <p>Вам надійшов запит на затвердження змін в обліковому записі компанії {{ profile_name }} на сайті CraftMerge.</p>
         <p>Перегляньте зміни та затвердіть або скасуйте їх.</p>
+        {% else %}
+        <p>Інформуємо про те що попередньо доданий контент було видалено</p>
+        {% endif %}
         <p><b>Дата змін: </b>{{ updated_at }} UTC</p>
         {% if banner %}
         <p><b>Банер:</b></p>
@@ -59,11 +63,15 @@
             <img src="cid:{{ logo.uuid }}" alt="Логотип"/>
         </div>
         {% endif %}
+        {% if not banner_logo_deleted %}
         <div style="margin: 20px 0;">
             <a href="{{protocol}}://{{ domain }}/{{ approve_url }}" class="button button-approve">ЗАТВЕРДИТИ</a>
             <a href="#" class="button button-reject">СКАСУВАТИ</a>
         </div>
         <p><b>Примітка:</b> <i>запит буде автоматично затверджений через {{ moderation_time }}</i></p>
+        {% else %}
+        <p>Запит на модерацію <b>скасовано</b>.</p>
+        {% endif %}
         <p>З повагою,</p>
         <p>Команда CraftMerge</p>
     </div>

--- a/BackEnd/profiles/tests/test_email_sending.py
+++ b/BackEnd/profiles/tests/test_email_sending.py
@@ -135,8 +135,8 @@ class TestSendModerationManager(APITestCase):
         self.assertFalse(self.manager.needs_moderation(self.profile.logo))
 
     @mock.patch("utils.moderation.image_moderation.now", return_value=now())
-    def test_update_status(self, mock_now):
-        self.manager.update_status()
+    def test_update_pending_status(self, mock_now):
+        self.manager.update_pending_status()
         self.assertEqual(self.profile.status, "pending")
         self.assertEqual(self.profile.status_updated_at, mock_now.return_value)
         self.assertTrue(self.manager.moderation_is_needed)

--- a/BackEnd/profiles/tests/test_email_sending.py
+++ b/BackEnd/profiles/tests/test_email_sending.py
@@ -129,10 +129,10 @@ class TestSendModerationManager(APITestCase):
         self.assertFalse(self.manager.needs_moderation(self.logo))
 
     def test_needs_moderation_deleted_image(self):
-        self.banner.is_deleted = True
-        self.logo.is_deleted = True
-        self.assertFalse(self.manager.needs_moderation(self.banner))
-        self.assertFalse(self.manager.needs_moderation(self.logo))
+        self.profile.banner = None
+        self.profile.logo = None
+        self.assertFalse(self.manager.needs_moderation(self.profile.banner))
+        self.assertFalse(self.manager.needs_moderation(self.profile.logo))
 
     @mock.patch("utils.moderation.image_moderation.now", return_value=now())
     def test_update_status(self, mock_now):
@@ -156,8 +156,7 @@ class TestSendModerationManager(APITestCase):
 
     @mock.patch("utils.moderation.image_moderation.now", return_value=now())
     def test_check_for_moderation_deleted_banner(self, mock_now):
-        self.banner.is_deleted = True
-        self.profile.banner = self.banner
+        self.profile.banner = None
         self.profile.logo = self.logo
         self.manager.check_for_moderation()
         self.assertEqual(self.profile.status, "pending")
@@ -169,9 +168,8 @@ class TestSendModerationManager(APITestCase):
 
     @mock.patch("utils.moderation.image_moderation.now", return_value=now())
     def test_check_for_moderation_deleted_logo(self, mock_now):
-        self.logo.is_deleted = True
         self.profile.banner = self.banner
-        self.profile.logo = self.logo
+        self.profile.logo = None
         self.manager.check_for_moderation()
         self.assertEqual(self.profile.status, "pending")
         self.assertEqual(self.profile.status_updated_at, mock_now.return_value)
@@ -182,10 +180,8 @@ class TestSendModerationManager(APITestCase):
 
     # needs improvement for undefined status
     def test_check_for_moderation_deleted_both(self):
-        self.banner.is_deleted = True
-        self.profile.banner = self.banner
-        self.logo.is_deleted = True
-        self.profile.logo = self.logo
+        self.profile.banner = None
+        self.profile.logo = None
         self.manager.check_for_moderation()
         self.assertFalse(self.manager.moderation_is_needed)
         self.assertEqual(

--- a/BackEnd/utils/moderation/handle_approved_images.py
+++ b/BackEnd/utils/moderation/handle_approved_images.py
@@ -1,0 +1,19 @@
+from ..completeness_counter import completeness_count
+
+
+class ApprovedImages:
+    def __init__(self, profile):
+        self.profile = profile
+
+    def delete_approved_image(self, approved_image):
+        if self.profile.status == self.profile.PENDING and approved_image:
+            approved_image.is_deleted = True
+            approved_image.save()
+            completeness_count(self.profile)
+    
+    def check_approved_images(self):
+        if self.profile.banner and self.profile.banner.is_deleted:
+            self.delete_approved_image(self.profile.banner_approved)
+
+        if self.profile.logo and self.profile.logo.is_deleted:
+            self.delete_approved_image(self.profile.logo_approved)

--- a/BackEnd/utils/moderation/handle_approved_images.py
+++ b/BackEnd/utils/moderation/handle_approved_images.py
@@ -10,7 +10,7 @@ class ApprovedImages:
             approved_image.is_deleted = True
             approved_image.save()
             completeness_count(self.profile)
-    
+
     def check_approved_images(self):
         if self.profile.banner and self.profile.banner.is_deleted:
             self.delete_approved_image(self.profile.banner_approved)

--- a/BackEnd/utils/moderation/handle_approved_images.py
+++ b/BackEnd/utils/moderation/handle_approved_images.py
@@ -12,8 +12,8 @@ class ApprovedImages:
             completeness_count(self.profile)
 
     def check_approved_images(self):
-        if self.profile.banner and self.profile.banner.is_deleted:
+        if not self.profile.banner:
             self.delete_approved_image(self.profile.banner_approved)
 
-        if self.profile.logo and self.profile.logo.is_deleted:
+        if not self.profile.logo:
             self.delete_approved_image(self.profile.logo_approved)

--- a/BackEnd/utils/moderation/image_moderation.py
+++ b/BackEnd/utils/moderation/image_moderation.py
@@ -1,11 +1,44 @@
 from django.utils.timezone import now
 
+from utils.completeness_counter import completeness_count
+
 
 class ModerationManager:
     def __init__(self, profile):
         self.profile = profile
         self.moderation_is_needed = False
         self.banner_logo = {"banner": None, "logo": None}
+        self.content_deleted = False
+
+    def handle_approved_status(self, primary_image, secondary_image):
+        if primary_image.is_deleted and secondary_image.is_approved:
+            self.profile.status = self.profile.APPROVED
+            self.profile.status_updated_at = now()
+            self.content_deleted = True
+            self.profile.save()
+
+    def delete_approved_image(self, approved_image):
+        if self.profile.status == self.profile.PENDING and approved_image:
+            approved_image.is_deleted = True
+            completeness_count(self.profile)  # needs improvement
+            approved_image.save()
+
+    def handle_undefined_status(self):
+        banner = self.profile.banner
+        logo = self.profile.logo
+
+        if (not banner or banner.is_deleted) and (not logo or logo.is_deleted):
+            if self.profile.status == self.profile.PENDING:
+                self.content_deleted = True
+            self.profile.status = self.profile.UNDEFINED
+            self.profile.status_updated_at = now()
+
+        if banner and banner.is_deleted:
+            self.delete_approved_image(self.profile.banner_approved)
+
+        if logo and logo.is_deleted:
+            self.delete_approved_image(self.profile.logo_approved)
+        self.profile.save()
 
     def update_status(self):
         self.profile.status = self.profile.PENDING
@@ -20,7 +53,22 @@ class ModerationManager:
         if self.needs_moderation(self.profile.banner):
             self.update_status()
             self.banner_logo["banner"] = self.profile.banner
+        elif (
+            self.profile.banner
+            and self.profile.logo
+            and self.profile.status == self.profile.PENDING
+        ):
+            self.handle_approved_status(self.profile.banner, self.profile.logo)
+
         if self.needs_moderation(self.profile.logo):
             self.update_status()
             self.banner_logo["logo"] = self.profile.logo
+        elif (
+            self.profile.banner
+            and self.profile.logo
+            and self.profile.status == self.profile.PENDING
+        ):
+            self.handle_approved_status(self.profile.logo, self.profile.banner)
+
+        self.handle_undefined_status()
         return self.moderation_is_needed

--- a/BackEnd/utils/moderation/image_moderation.py
+++ b/BackEnd/utils/moderation/image_moderation.py
@@ -29,7 +29,7 @@ class ModerationManager:
             self.profile.status_updated_at = now()
         self.profile.save()
 
-    def update_status(self):
+    def update_pending_status(self):
         self.profile.status = self.profile.PENDING
         self.profile.status_updated_at = now()
         self.profile.save()
@@ -40,13 +40,13 @@ class ModerationManager:
 
     def check_for_moderation(self):
         if self.needs_moderation(self.profile.banner):
-            self.update_status()
+            self.update_pending_status()
             self.banner_logo["banner"] = self.profile.banner
         elif not self.profile.banner and self.profile.logo:
             self.handle_approved_status(self.profile.logo)
 
         if self.needs_moderation(self.profile.logo):
-            self.update_status()
+            self.update_pending_status()
             self.banner_logo["logo"] = self.profile.logo
         elif not self.profile.logo and self.profile.banner:
             self.handle_approved_status(self.profile.banner)

--- a/BackEnd/utils/moderation/image_moderation.py
+++ b/BackEnd/utils/moderation/image_moderation.py
@@ -17,12 +17,6 @@ class ModerationManager:
             self.content_deleted = True
             self.profile.save()
 
-    def delete_approved_image(self, approved_image):
-        if self.profile.status == self.profile.PENDING and approved_image:
-            approved_image.is_deleted = True
-            completeness_count(self.profile)  # needs improvement
-            approved_image.save()
-
     def handle_undefined_status(self):
         banner = self.profile.banner
         logo = self.profile.logo
@@ -32,12 +26,6 @@ class ModerationManager:
                 self.content_deleted = True
             self.profile.status = self.profile.UNDEFINED
             self.profile.status_updated_at = now()
-
-        if banner and banner.is_deleted:
-            self.delete_approved_image(self.profile.banner_approved)
-
-        if logo and logo.is_deleted:
-            self.delete_approved_image(self.profile.logo_approved)
         self.profile.save()
 
     def update_status(self):

--- a/BackEnd/utils/moderation/image_moderation.py
+++ b/BackEnd/utils/moderation/image_moderation.py
@@ -1,7 +1,5 @@
 from django.utils.timezone import now
 
-from utils.completeness_counter import completeness_count
-
 
 class ModerationManager:
     def __init__(self, profile):

--- a/BackEnd/utils/moderation/image_moderation.py
+++ b/BackEnd/utils/moderation/image_moderation.py
@@ -8,8 +8,8 @@ class ModerationManager:
         self.banner_logo = {"banner": None, "logo": None}
         self.content_deleted = False
 
-    def handle_approved_status(self, primary_image, secondary_image):
-        if primary_image.is_deleted and secondary_image.is_approved:
+    def handle_approved_status(self, secondary_image):
+        if self.profile.status == self.profile.PENDING and secondary_image.is_approved:
             self.profile.status = self.profile.APPROVED
             self.profile.status_updated_at = now()
             self.content_deleted = True
@@ -19,7 +19,7 @@ class ModerationManager:
         banner = self.profile.banner
         logo = self.profile.logo
 
-        if (not banner or banner.is_deleted) and (not logo or logo.is_deleted):
+        if not banner and not logo:
             if self.profile.status == self.profile.PENDING:
                 self.content_deleted = True
             self.profile.status = self.profile.UNDEFINED
@@ -33,28 +33,20 @@ class ModerationManager:
         self.moderation_is_needed = True
 
     def needs_moderation(self, image):
-        return image and not image.is_approved and not image.is_deleted
+        return image and not image.is_approved
 
     def check_for_moderation(self):
         if self.needs_moderation(self.profile.banner):
             self.update_status()
             self.banner_logo["banner"] = self.profile.banner
-        elif (
-            self.profile.banner
-            and self.profile.logo
-            and self.profile.status == self.profile.PENDING
-        ):
-            self.handle_approved_status(self.profile.banner, self.profile.logo)
+        elif not self.profile.banner and self.profile.logo:
+            self.handle_approved_status(self.profile.logo)
 
         if self.needs_moderation(self.profile.logo):
             self.update_status()
             self.banner_logo["logo"] = self.profile.logo
-        elif (
-            self.profile.banner
-            and self.profile.logo
-            and self.profile.status == self.profile.PENDING
-        ):
-            self.handle_approved_status(self.profile.logo, self.profile.banner)
+        elif not self.profile.logo and self.profile.banner:
+            self.handle_approved_status(self.profile.banner)
 
         self.handle_undefined_status()
         return self.moderation_is_needed

--- a/BackEnd/utils/moderation/image_moderation.py
+++ b/BackEnd/utils/moderation/image_moderation.py
@@ -9,7 +9,10 @@ class ModerationManager:
         self.content_deleted = False
 
     def handle_approved_status(self, secondary_image):
-        if self.profile.status == self.profile.PENDING and secondary_image.is_approved:
+        if (
+            self.profile.status == self.profile.PENDING
+            and secondary_image.is_approved
+        ):
             self.profile.status = self.profile.APPROVED
             self.profile.status_updated_at = now()
             self.content_deleted = True

--- a/BackEnd/utils/moderation/send_email.py
+++ b/BackEnd/utils/moderation/send_email.py
@@ -51,7 +51,7 @@ def attach_image(email, image, content_id):
 
 def send_moderation_email(profile):
     manager = ModerationManager(profile)
-    if manager.check_for_moderation():
+    if manager.check_for_moderation() or manager.content_deleted:
         update_time = profile.status_updated_at.strftime("%d.%m.%Y %H:%M")
         update_date = profile.status_updated_at.strftime("%d.%m.%Y")
         banner = manager.banner_logo["banner"]
@@ -62,6 +62,7 @@ def send_moderation_email(profile):
             "domain": DOMAIN,
             "banner": banner,
             "logo": logo,
+            "banner_logo_deleted": manager.content_deleted,
             "updated_at": update_time,
             "moderation_time": define_ending(
                 AutoModeration.get_auto_moderation_hours().auto_moderation_hours

--- a/BackEnd/utils/moderation/send_email.py
+++ b/BackEnd/utils/moderation/send_email.py
@@ -6,6 +6,7 @@ from email.mime.image import MIMEImage
 from django.core.mail import EmailMultiAlternatives
 from django.conf import settings
 from django.template.loader import render_to_string
+from .handle_approved_images import ApprovedImages
 from administration.models import AutoModeration
 from .image_moderation import ModerationManager
 from .encode_decode_id import encode_id
@@ -51,7 +52,10 @@ def attach_image(email, image, content_id):
 
 def send_moderation_email(profile):
     manager = ModerationManager(profile)
-    if manager.check_for_moderation() or manager.content_deleted:
+    approved_images = ApprovedImages(profile)
+    email_is_needed = manager.check_for_moderation()
+    approved_images.check_approved_images()
+    if email_is_needed or manager.content_deleted:
         update_time = profile.status_updated_at.strftime("%d.%m.%Y %H:%M")
         update_date = profile.status_updated_at.strftime("%d.%m.%Y")
         banner = manager.banner_logo["banner"]

--- a/FrontEnd/src/utils/defineChanges.js
+++ b/FrontEnd/src/utils/defineChanges.js
@@ -26,7 +26,7 @@ const defineChanges = (fields, profile, user) => {
         } else {
             if (!compareValues(defaultValue, currentValue, type)) {
                 if (type === 'image') {
-                    profileChanges[field] = currentValue?.uuid;
+                    profileChanges[field] = currentValue?.uuid || null;
                 } else if (['regions', 'activities', 'categories'].includes(field)) {
                     profileChanges[field] = currentValue.map((obj) => obj.id);
                 } else if (field === 'phone') {


### PR DESCRIPTION

When images under moderation are deleted, an email should be sent indicating that the moderation request has been canceled. If only one image is deleted, the email should be sent with the remaining image still under moderation. **Additionally, when an image is deleted, it should be set to None in the profile.** Also, update the status to "undefined" when all content is deleted.