### PR TITLE
Configure Nginx to serve Django media files

### DIFF
--- a/.github/workflows/django_cd_dev.yml
+++ b/.github/workflows/django_cd_dev.yml
@@ -43,8 +43,6 @@ jobs:
         run: docker compose -f docker-compose.dev.yml exec ${{ vars.API_DEV }} python manage.py loaddata categories
       - name: Docker compose LOADDATA regions
         run: docker compose -f docker-compose.dev.yml exec ${{ vars.API_DEV }} python manage.py loaddata regions
-      - name: Docker compose COLLECTSTATIC
-        run: docker compose -f docker-compose.dev.yml exec ${{ vars.API_DEV }} python manage.py collectstatic --no-input
       - name: nginx
         run: docker compose -f docker-compose.nginx.yml down -v
       - name: nginx

--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -10,11 +10,12 @@ server {
         proxy_redirect off;
     }
 
+    # Media files
     location /media/ {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
-        proxy_pass http://api-dev:8000/media/;
-        proxy_redirect off;
+        alias /home/forum/app/public/media/; 
+        access_log off;
+        expires 30d;
+        add_header Cache-Control 'public, no-transform';
     }
 
     # Django API

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -82,8 +82,6 @@ services:
   redis:
     image: redis:7
     container_name: redis
-    ports:
-      - 6379:6379
     networks:
       - forum_network
 networks:

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -8,5 +8,13 @@ services:
       - 80:80
     networks:
       - forum_network
+    volumes:
+      - media:/home/forum/app/public/media
+
 networks:
   forum_network:
+
+volumes:
+  media:
+    external:
+      name: forum_media    


### PR DESCRIPTION
Modified the Nginx configuration to directly serve Django media files, as Django does not serve them in production mode. The `location /media/ ` block was updated, and a volume mount for forum_media was added to the Nginx container. The unnecessary collectstatic command was also removed from django_cd_dev.