### PR TITLE
Fix duplication in the admin menu item IDs and adjust their order.

### DIFF
--- a/FrontEnd/src/pages/AdminPage/Menu/Menu.jsx
+++ b/FrontEnd/src/pages/AdminPage/Menu/Menu.jsx
@@ -16,17 +16,17 @@ const MENU = [
         link: '/customadmin/profiles/'
     },
     {
-        id: 'am4',
+        id: 'am3',
         title: 'Контакти',
         link: '/customadmin/contacts/'
     },
     {
-        id: 'am3',
+        id: 'am4',
         title: 'Зміна часу автомодерації',
         link: '/customadmin/automoderation/'
     },
     {
-        id: 'am4',
+        id: 'am5',
         title: 'Пошта адміністратора',
         link: '/customadmin/email/'
     }


### PR DESCRIPTION
There is duplication in the id's of admin menu items, that leads to a warning in the console.