### PR TITLE
Fixed company icon issue

### DIFF
--- a/FrontEnd/src/components/Header/Navbar/Profile.jsx
+++ b/FrontEnd/src/components/Header/Navbar/Profile.jsx
@@ -27,11 +27,11 @@ function Profile() {
 
   return (
     <div className={css['header-profile-section']}>
-      <div className={css['header-profile__avatar']}>
+      <div className={css['header-profile__avatar']}
+           onClick={!isStaff ? navigateToProfile : null}>
         <img
           src={`${process.env.REACT_APP_PUBLIC_URL}/img/Avatar.png`}
           alt="Avatar"
-          onClick={!isStaff ? navigateToProfile : null}
         />
       </div>
       <div className={css['dropdown-section']}>


### PR DESCRIPTION
Problem:
The 'Company' icon in the top-right corner of the header only triggered the expected action when clicking directly on the image. Clicking on the empty space within the circle did not work.

Solution:
The onClick handler was moved from the <img> tag to the parent <div> container, ensuring that the entire circle is clickable, not just the image.

Changes:
Updated the Profile component to attach the click event to the container instead of the image.
No changes were made to the functionality, only improved the user experience (UX).
Testing:
Verified that clicking anywhere within the circle correctly opens the company information tab.
Related Issue:
Issue #928

