### PR TITLE
fixed the length of the main banner in the mobile version

### DIFF
--- a/FrontEnd/src/pages/LandingPage/Banner/Banner.module.css
+++ b/FrontEnd/src/pages/LandingPage/Banner/Banner.module.css
@@ -127,6 +127,6 @@
         letter-spacing: 0.01em;
     }
     .main-banner__img{
-        max-width: 344px;
+        max-width: 314px;
     }
 }


### PR DESCRIPTION
fix the display of the main banner in the heroes section when the screen size is "mobile phone".

![зображення](https://github.com/user-attachments/assets/47e606da-5bdf-450a-8cae-6269cba44b35)
