### PR TITLE
move the pagination block to the center of the page

### DIFF
--- a/FrontEnd/src/pages/AdminPage/UserProfilesTable/UserTable.jsx
+++ b/FrontEnd/src/pages/AdminPage/UserProfilesTable/UserTable.jsx
@@ -9,7 +9,7 @@ import css from './UserTable.module.scss';
 
 
 const LENGTH_EMAIL = 14;
-const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 10;
 
 function UserTable() {
     const location = useLocation();
@@ -244,12 +244,12 @@ function UserTable() {
     return (
         <div className={css['table-container']}>
             <Pagination
+                showSizeChanger
                 current={currentPage}
                 pageSize={pageSize}
                 total={totalItems}
                 onChange={handlePageChange}
                 onShowSizeChange={handlePageChange}
-                showSizeChanger={false}
                 showTitle={false}
                 className={css['pagination']}
             />
@@ -265,6 +265,16 @@ function UserTable() {
                     triggerAsc: 'Сортувати в порядку зростання',
                     cancelSort: 'Відмінити сортування',
                 }}
+            />
+            <Pagination
+                showSizeChanger
+                current={currentPage}
+                pageSize={pageSize}
+                total={totalItems}
+                onChange={handlePageChange}
+                onShowSizeChange={handlePageChange}
+                showTitle={false}
+                className={css['pagination']}
             />
         </div>
     );

--- a/FrontEnd/src/pages/AdminPage/UserProfilesTable/UserTable.module.scss
+++ b/FrontEnd/src/pages/AdminPage/UserProfilesTable/UserTable.module.scss
@@ -29,6 +29,7 @@
 .pagination {
     margin-top: 16px;
     text-align: center;
+    justify-content: center;
     margin-bottom: 16px;
 }
 

--- a/FrontEnd/src/routes/AdminRouter.jsx
+++ b/FrontEnd/src/routes/AdminRouter.jsx
@@ -59,6 +59,9 @@ function AdminRouter() {
                     filterReset: 'Скинути',
                     filterConfirm: 'Застосувати',
                 },
+                Pagination: {
+                    items_per_page: '/ сторінка'
+                }
             }}
         >
             <BurgerMenuProvider>


### PR DESCRIPTION
moved the pagination block to the center of the page and added functionality to select how many users display per page (e.g., 10, 20, or 50) using a dropdown.