### PR TITLE
#1041 truncate region name in company profile title

### DIFF
--- a/FrontEnd/src/pages/ProfileDetail/TitelInfo/TitleInfo.jsx
+++ b/FrontEnd/src/pages/ProfileDetail/TitelInfo/TitleInfo.jsx
@@ -12,11 +12,16 @@ import { useAuth } from '../../../hooks';
 
 import classes from './TitleInfo.module.css';
 
+function truncateRegionName(regionName) {
+  if (!regionName) return '';
+  return regionName.replace(/область/g, 'обл.');
+}
 
-function TitleInfo({ isAuthorized, data }) {
+export default function TitleInfo({ isAuthorized, data }) {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [isSaved, setIsSaved] = useState(data.is_saved);
+
   const profile = useMemo(() => {
     return {
       id: data.id,
@@ -26,8 +31,8 @@ function TitleInfo({ isAuthorized, data }) {
         data.activities && data.activities.length
           ? data.activities.map((activity) => activity.name).join(', ')
           : null,
-      regions: data.regions_ukr_display ? data.regions_ukr_display : '',
-      categories: data.categories ? data.categories : null,
+      regions: truncateRegionName(data.regions_ukr_display),
+      categories: data.categories || [],
       isSaved: data.is_saved,
       logo: data.logo,
     };
@@ -93,9 +98,9 @@ function TitleInfo({ isAuthorized, data }) {
             </div>
           </div>
         </div>
-        {isAuthorized ? (
+        {isAuthorized && (
           <div className={classes['title-block__button-block']}>
-            {!ownProfile && (
+            {!ownProfile ? (
               <button
                 onClick={isSaved ? handleDeleteSaved : handleSave}
                 type="button"
@@ -111,33 +116,27 @@ function TitleInfo({ isAuthorized, data }) {
                   {!isSaved ? 'Додати в збережені' : 'Додано в збережені'}
                 </span>
                 <StarForLike
-                  location="profilePage"
                   isSaved={isSaved}
                   isAuthorized={isAuthorized}
                   ownProfile={ownProfile}
                   styleOutlined={{ color: isSaved ? '#FFF' : '#000', fontSize: '24px' }}
-                ></StarForLike>
+                />
               </button>
-            )}
-            {ownProfile && (
+            ) : (
               <a
                 role="link"
                 className={`${classes['title-block__button']} ${classes['title-block__link']}`}
                 onClick={navigateToEditProfile}
               >
-                <span className={`${classes['title-block__button--text']}`}>
-                  Редагувати
-                </span>
+                <span className={classes['title-block__button--text']}>Редагувати</span>
               </a>
             )}
           </div>
-        ) : null}
+        )}
       </div>
     </div>
   );
 }
-
-export default TitleInfo;
 
 TitleInfo.propTypes = {
   isAuthorized: PropTypes.bool,

--- a/FrontEnd/src/pages/ProfileDetail/TitelInfo/TitleInfo.jsx
+++ b/FrontEnd/src/pages/ProfileDetail/TitelInfo/TitleInfo.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { PropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import DefaultLogo from './DefaultLogo';
@@ -9,13 +9,9 @@ import PendingStatus from '../../../components/MiniComponents/PendingModerationI
 import CategoryBadges from '../../../components/MiniComponents/CategoryBadges';
 import StarForLike from '../../../components/MiniComponents/StarForLike';
 import { useAuth } from '../../../hooks';
+import truncateRegionName from '../../../utils/truncateRegionName';
 
 import classes from './TitleInfo.module.css';
-
-function truncateRegionName(regionName) {
-  if (!regionName) return '';
-  return regionName.replace(/область/g, 'обл.');
-}
 
 export default function TitleInfo({ isAuthorized, data }) {
   const { user } = useAuth();
@@ -28,9 +24,9 @@ export default function TitleInfo({ isAuthorized, data }) {
       personId: data.person,
       name: data.name,
       activities:
-        data.activities && data.activities.length
+        data.activities?.length
           ? data.activities.map((activity) => activity.name).join(', ')
-          : null,
+          : '',
       regions: truncateRegionName(data.regions_ukr_display),
       categories: data.categories || [],
       isSaved: data.is_saved,

--- a/FrontEnd/src/pages/ProfileDetail/TitelInfo/test/TitleInfo.test.js
+++ b/FrontEnd/src/pages/ProfileDetail/TitelInfo/test/TitleInfo.test.js
@@ -1,0 +1,119 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TitleInfo from '../TitleInfo';
+import { useAuth } from '../../../../hooks/useAuth';
+
+jest.mock('../../../../hooks/useAuth', () => ({
+  useAuth: jest.fn(),
+}));
+
+afterEach(cleanup);
+
+describe('TitleInfo component unit tests', () => {
+  const baseData = {
+    id: 1,
+    name: 'Test Company',
+    person: 1,
+    regions_ukr_display: '',
+    activities: [],
+    categories: [],
+    is_saved: false,
+    logo: null,
+  };
+
+  beforeEach(() => {
+    useAuth.mockReturnValue({
+      user: {
+        id: 1,
+        email: 'test@example.com',
+        name: 'Test User',
+      },
+    });
+  });
+
+  test('renders with shortened region', () => {
+    const testData = {
+      ...baseData,
+      regions_ukr_display: 'Київська область, Кіровоградська область',
+    };
+
+    render(
+      <MemoryRouter>
+        <TitleInfo isAuthorized={true} data={testData} />
+      </MemoryRouter>
+    );
+
+    const regionElement = screen.getByText(/Київська обл., Кіровоградська обл./i);
+    expect(regionElement).toBeInTheDocument();
+  });
+
+  test('renders without region', () => {
+    render(
+      <MemoryRouter>
+        <TitleInfo isAuthorized={true} data={baseData} />
+      </MemoryRouter>
+    );
+
+    const regionElement = screen.queryByText(/обл./i);
+    expect(regionElement).not.toBeInTheDocument();
+  });
+
+  test('renders activities and categories', () => {
+    const testData = {
+      ...baseData,
+      activities: [
+        { id: 1, name: 'IT Development' },
+        { id: 2, name: 'Education' },
+      ],
+      categories: [
+        { id: 1, name: 'Software' },
+        { id: 2, name: 'Hardware' },
+      ],
+    };
+
+    render(
+      <MemoryRouter>
+        <TitleInfo isAuthorized={true} data={testData} />
+      </MemoryRouter>
+    );
+
+    const activityElement = screen.getByText(/IT Development, Education/i);
+    const categoryElement = screen.getByText(/Software/i);
+
+    expect(activityElement).toBeInTheDocument();
+    expect(categoryElement).toBeInTheDocument();
+  });
+
+  test('renders saved button for non-owner', () => {
+    const testData = {
+      ...baseData,
+      person: 2,
+      regions_ukr_display: 'Київська область',
+    };
+
+    render(
+      <MemoryRouter>
+        <TitleInfo isAuthorized={true} data={testData} />
+      </MemoryRouter>
+    );
+
+    const buttonElement = screen.getByText(/Додати в збережені/i);
+    expect(buttonElement).toBeInTheDocument();
+  });
+
+  test('renders edit link for owner', () => {
+    const testData = {
+      ...baseData,
+      regions_ukr_display: 'Київська область',
+    };
+
+    render(
+      <MemoryRouter>
+        <TitleInfo isAuthorized={true} data={testData} />
+      </MemoryRouter>
+    );
+
+    const linkElement = screen.getByText(/Редагувати/i);
+    expect(linkElement).toBeInTheDocument();
+  });
+});

--- a/FrontEnd/src/utils/truncateRegionName.js
+++ b/FrontEnd/src/utils/truncateRegionName.js
@@ -1,0 +1,4 @@
+export default function truncateRegionName(regionName) {
+    if (!regionName) return '';
+    return regionName.replace(/область/g, 'обл.');
+  }


### PR DESCRIPTION
1.Added the TitleInfo component to display profile info with support for region shortening.

2.Wrote unit tests to verify:
- Region shortening.
- Display of activities and categories.
- Save button for non-owners.
- Edit link for owners.

All tests are passing.
![1](https://github.com/user-attachments/assets/4d996ae9-3776-4274-93d4-82594b3c9a8e)
![2](https://github.com/user-attachments/assets/ea8c857d-0af1-411b-a724-a8acfc37f134)
