### PR TITLE
#1075 [BE] Update Profile manager to display visible only profiles

### DIFF
--- a/BackEnd/profiles/factories.py
+++ b/BackEnd/profiles/factories.py
@@ -54,17 +54,24 @@ class ProfileFactory(factory.django.DjangoModelFactory):
 
     @factory.post_generation
     def activities(self, create, extracted):
-        if not create or not extracted:
+        if not create:
             return
-        self.activities.add(*extracted)
+        if extracted is not None:
+            self.activities.add(*extracted)
+        else:
+            activity = ActivityFactory()
+            self.activities.add(activity)
 
     @factory.post_generation
     def categories(self, create, extracted):
         if not create:
             return
-        if extracted:
+        if extracted is not None:
             for category in extracted:
                 self.categories.add(category)
+        else:
+            category = CategoryFactory()
+            self.categories.add(category)
 
     @factory.post_generation
     def regions(self, create, extracted):

--- a/BackEnd/profiles/factories.py
+++ b/BackEnd/profiles/factories.py
@@ -53,7 +53,7 @@ class ProfileFactory(factory.django.DjangoModelFactory):
     is_deleted = False
 
     @factory.post_generation
-    def activities(self, create, extracted):
+    def activities(self, create, extracted=None):
         if not create:
             return
         if extracted is not None:
@@ -63,7 +63,7 @@ class ProfileFactory(factory.django.DjangoModelFactory):
             self.activities.add(activity)
 
     @factory.post_generation
-    def categories(self, create, extracted):
+    def categories(self, create, extracted=None):
         if not create:
             return
         if extracted is not None:

--- a/BackEnd/profiles/managers.py
+++ b/BackEnd/profiles/managers.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.db.models import Q, Count, OuterRef, Exists
+from django.db.models import Q
 
 
 class ProfileManager(models.QuerySet):

--- a/BackEnd/profiles/managers.py
+++ b/BackEnd/profiles/managers.py
@@ -1,6 +1,18 @@
 from django.db import models
+from django.db.models import Q, Count, OuterRef, Exists
 
 
 class ProfileManager(models.QuerySet):
     def active_only(self):
         return self.filter(is_deleted=False, person__is_active=True)
+
+    def visible_only(self):
+        return self.filter(
+            is_deleted=False,
+            person__is_active=True,
+        ).exclude(
+            Q(name__isnull=True)
+            | Q(common_info="")
+            | Q(categories__isnull=True)
+            | Q(activities__isnull=True)
+        )

--- a/BackEnd/profiles/managers.py
+++ b/BackEnd/profiles/managers.py
@@ -12,6 +12,7 @@ class ProfileManager(models.QuerySet):
             person__is_active=True,
         ).exclude(
             Q(name__isnull=True)
+            | Q(official_name__isnull=True)
             | Q(common_info="")
             | Q(categories__isnull=True)
             | Q(activities__isnull=True)

--- a/BackEnd/profiles/tests/test_crud_profile.py
+++ b/BackEnd/profiles/tests/test_crud_profile.py
@@ -123,11 +123,15 @@ class TestProfileDetailAPIView(APITestCase):
             response.data.get("logo"),
             msg="Logo images do not match.",
         )
-        self.assertFalse(
-            response.data.get("categories"), msg="Categories do not match."
+        self.assertEqual(
+            list(self.profile.categories.values("id", "name")),
+            response.data.get("categories"),
+            msg="Categories do not match.",
         )
-        self.assertFalse(
-            response.data.get("activities"), msg="Activities do not match."
+        self.assertEqual(
+            list(self.profile.activities.values("id", "name")),
+            response.data.get("activities"),
+            msg="Activities do not match.",
         )
 
     def test_get_profile_authorized_not_owner(self):
@@ -204,20 +208,24 @@ class TestProfileDetailAPIView(APITestCase):
             msg="Product info do not match.",
         )
         self.assertEqual(
-            self.profile.banner,
+            profile2.banner,
             response.data.get("banner"),
             msg="Banner images do not match.",
         )
         self.assertEqual(
-            self.profile.logo,
+            profile2.logo,
             response.data.get("logo"),
             msg="Logo images do not match.",
         )
-        self.assertFalse(
-            response.data.get("categories"), msg="Categories do not match."
+        self.assertEqual(
+            list(profile2.categories.values("id", "name")),
+            response.data.get("categories"),
+            msg="Categories do not match.",
         )
-        self.assertFalse(
-            response.data.get("activities"), msg="Activities do not match."
+        self.assertEqual(
+            list(profile2.activities.values("id", "name")),
+            response.data.get("activities"),
+            msg="Activities do not match.",
         )
 
     def test_get_profile_authorized_owner(self):
@@ -316,12 +324,12 @@ class TestProfileDetailAPIView(APITestCase):
             msg="Logo images do not match.",
         )
         self.assertEqual(
-            list(self.profile.categories.all()),
+            list(self.profile.categories.values("id", "name")),
             response.data.get("categories"),
             msg="Categories do not match.",
         )
         self.assertEqual(
-            list(self.profile.activities.all()),
+            list(self.profile.activities.values("id", "name")),
             response.data.get("activities"),
             msg="Activities do not match.",
         )

--- a/BackEnd/profiles/tests/test_manager.py
+++ b/BackEnd/profiles/tests/test_manager.py
@@ -1,0 +1,122 @@
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from authentication.factories import UserFactory
+from profiles.factories import (
+    ProfileStartupFactory,
+    ProfileCompanyFactory,
+)
+
+from profiles.models import Profile
+from utils.dump_response import dump  # noqa
+
+
+class TestProfileManager(TestCase):
+    def setUp(self) -> None:
+        self.inactive_user = UserFactory(is_active=False)
+        self.active_and_visible_profile1 = ProfileCompanyFactory()
+        self.active_and_visible_profile2 = ProfileStartupFactory()
+        self.active_profile_only_categories = ProfileStartupFactory(
+            activities=[]
+        )
+        self.active_profile_only_activities = ProfileStartupFactory(
+            categories=[]
+        )
+        self.active_profile_without_common_info = ProfileStartupFactory(
+            common_info=""
+        )
+        self.active_profile_without_name = ProfileStartupFactory(name=None)
+
+        self.inactive_profile = ProfileCompanyFactory(
+            person=self.inactive_user
+        )
+        self.deleted_profile = ProfileCompanyFactory(is_deleted=True)
+
+    def test_active_only_profiles(self):
+        active_profiles = Profile.objects.active_only()
+
+        self.assertEqual(6, len(active_profiles))
+        self.assertNotIn(self.inactive_profile, active_profiles)
+        self.assertNotIn(self.deleted_profile, active_profiles)
+        for profile in active_profiles:
+            self.assertFalse(profile.is_deleted)
+            self.assertTrue(profile.person.is_active)
+
+    def test_visible_only_profiles(self):
+        visible_profiles = Profile.objects.visible_only()
+
+        self.assertEqual(2, len(visible_profiles))
+        for profile in visible_profiles:
+            self.assertFalse(profile.is_deleted)
+            self.assertTrue(profile.person.is_active)
+            self.assertIsNotNone(profile.common_info)
+            self.assertIsNotNone(profile.name)
+            self.assertTrue(profile.categories.exists())
+            self.assertTrue(profile.activities.exists())
+
+
+class TestProfileVisibleOnlyAPIView(APITestCase):
+    def setUp(self) -> None:
+        self.inactive_user = UserFactory(is_active=False)
+        self.visible_profile1 = ProfileCompanyFactory()
+        self.visible_profile2 = ProfileStartupFactory()
+        self.profile_only_categories = ProfileStartupFactory(activities=[])
+        self.inactive_profile = ProfileCompanyFactory(
+            person=self.inactive_user
+        )
+
+    def test_get_visible_only_profiles(self):
+        response = self.client.get(path="/api/profiles/")
+        visible_profiles = Profile.objects.visible_only()
+        expected_response = [
+            {
+                "id": self.visible_profile1.id,
+                "name": self.visible_profile1.name,
+                "person": self.visible_profile1.person_id,
+                "is_registered": self.visible_profile1.is_registered,
+                "is_startup": self.visible_profile1.is_startup,
+                "official_name": self.visible_profile1.official_name,
+                "regions": [],
+                "regions_ukr_display": "",
+                "common_info": self.visible_profile1.common_info,
+                "address": self.visible_profile1.address,
+                "founded": self.visible_profile1.founded,
+                "categories": list(
+                    self.visible_profile1.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.visible_profile1.activities.values("id", "name")
+                ),
+                "banner": None,
+                "logo": None,
+                "is_saved": False,
+                "saved_is_updated": False,
+            },
+            {
+                "id": self.visible_profile2.id,
+                "name": self.visible_profile2.name,
+                "person": self.visible_profile2.person_id,
+                "is_registered": self.visible_profile2.is_registered,
+                "is_startup": self.visible_profile2.is_startup,
+                "official_name": self.visible_profile2.official_name,
+                "regions": [],
+                "regions_ukr_display": "",
+                "common_info": self.visible_profile2.common_info,
+                "address": self.visible_profile2.address,
+                "founded": self.visible_profile2.founded,
+                "categories": list(
+                    self.visible_profile2.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.visible_profile2.activities.values("id", "name")
+                ),
+                "banner": None,
+                "logo": None,
+                "is_saved": False,
+                "saved_is_updated": False,
+            },
+        ]
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(len(visible_profiles), response.data["total_items"])
+        self.assertListEqual(expected_response, response.data["results"])

--- a/BackEnd/profiles/tests/test_new_members.py
+++ b/BackEnd/profiles/tests/test_new_members.py
@@ -41,6 +41,8 @@ class TestCompletenessUpdate(APITestCase):
             name="Kryvyi_rig_art",
             person=self.kryvyi_rig_user,
             regions=[self.dnipro_region],
+            categories=[],
+            activities=[],
         )
 
     def test_completeness_after_update_region(self):

--- a/BackEnd/profiles/views.py
+++ b/BackEnd/profiles/views.py
@@ -118,8 +118,14 @@ class ProfileList(ListCreateAPIView):
     def get_queryset(self):
         user_id = self.request.query_params.get("userid")
         queryset = (
-            Profile.objects.active_only()
-            .prefetch_related("regions", "categories", "activities")
+            Profile.objects.visible_only()
+            .prefetch_related(
+                "regions",
+                "categories",
+                "activities",
+                "banner_approved",
+                "logo_approved",
+            )
             .order_by("id")
         )
         if user_id:

--- a/BackEnd/search/tests/test_advanced_search.py
+++ b/BackEnd/search/tests/test_advanced_search.py
@@ -29,14 +29,14 @@ class TestCompanyFilter(APITestCase):
         self.company_charkiv = ProfileStartupFactory(
             name="Charkiv",
             official_name="Charkivgreen",
-            common_info="",
+            common_info="info",
             service_info="",
             product_info="official",
         )
         self.company_chernigiv = ProfileStartupFactory(
             name="Chernigiv",
             official_name="Chernigiveducation",
-            common_info="",
+            common_info="info",
             service_info="official",
             product_info="testing",
         )
@@ -50,7 +50,7 @@ class TestCompanyFilter(APITestCase):
         self.company_testing = ProfileStartupFactory(
             name="testing",
             official_name="official",
-            common_info="",
+            common_info="info",
             service_info="",
             product_info="",
         )
@@ -138,8 +138,12 @@ class TestCompanyFilter(APITestCase):
                 "id": self.company_kyiv.id,
                 "name": "Kyiv",
                 "official_name": "Kyivbud",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_kyiv.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_kyiv.activities.values("id", "name")
+                ),
                 "regions": [],
                 "regions_ukr_display": "",
                 "common_info": "testing",

--- a/BackEnd/search/tests/test_search_by_name_region.py
+++ b/BackEnd/search/tests/test_search_by_name_region.py
@@ -12,6 +12,8 @@ from utils.dump_response import dump  # noqa
 
 
 class TestCompanyFilter(APITestCase):
+    maxDiff = None
+
     def setUp(self) -> None:
         self.user = UserFactory()
         self.kyiv_region = RegionFactory(name_eng="Kyiv", name_ukr="Київ")
@@ -51,8 +53,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_dnipro.id,
                     "name": "Dniprotrans",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_dnipro.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_dnipro.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.dnipro_region.id,
@@ -82,8 +88,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_dnipro.id,
                     "name": "Dniprotrans",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_dnipro.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_dnipro.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.dnipro_region.id,
@@ -113,8 +123,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_dnipro.id,
                     "name": "Dniprotrans",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_dnipro.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_dnipro.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.dnipro_region.id,
@@ -143,8 +157,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_dnipro.id,
                     "name": "Dniprotrans",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_dnipro.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_dnipro.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.dnipro_region.id,
@@ -174,8 +192,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_dnipro.id,
                     "name": "Dniprotrans",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_dnipro.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_dnipro.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.dnipro_region.id,
@@ -204,8 +226,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_dnipro.id,
                     "name": "Dniprotrans",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_dnipro.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_dnipro.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.dnipro_region.id,
@@ -235,8 +261,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_dnipro.id,
                     "name": "Dniprotrans",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_dnipro.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_dnipro.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.dnipro_region.id,
@@ -292,8 +322,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_kiev.id,
                     "name": "Kyivbud",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_kiev.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_kiev.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.kyiv_region.id,
@@ -348,8 +382,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_kiev.id,
                     "name": "Kyivbud",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_kiev.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_kiev.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.kyiv_region.id,
@@ -381,8 +419,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_kiev.id,
                     "name": "Kyivbud",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_kiev.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_kiev.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.kyiv_region.id,
@@ -482,8 +524,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_kiev.id,
                     "name": "Kyivbud",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_kiev.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_kiev.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.kyiv_region.id,
@@ -512,8 +558,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_kiev.id,
                     "name": "Kyivbud",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_kiev.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_kiev.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.kyiv_region.id,
@@ -547,8 +597,12 @@ class TestCompanyFilter(APITestCase):
                 {
                     "id": self.company_kiev.id,
                     "name": "Kyivbud",
-                    "categories": [],
-                    "activities": [],
+                    "categories": list(
+                        self.company_kiev.categories.values("id", "name")
+                    ),
+                    "activities": list(
+                        self.company_kiev.activities.values("id", "name")
+                    ),
                     "regions": [
                         {
                             "id": self.kyiv_region.id,
@@ -586,8 +640,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_charkiv.id,
                 "name": "Charkivmarket",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_charkiv.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_charkiv.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.kharkiv_region.id,
@@ -606,8 +664,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_chernigiv.id,
                 "name": "Chernigivtravel",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_chernigiv.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_chernigiv.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.chernihiv_region.id,
@@ -626,8 +688,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_dnipro.id,
                 "name": "Dniprotrans",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_dnipro.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_dnipro.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.dnipro_region.id,
@@ -646,8 +712,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_kiev.id,
                 "name": "Kyivbud",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_kiev.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_kiev.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.kyiv_region.id,
@@ -678,8 +748,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_charkiv.id,
                 "name": "Charkivmarket",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_charkiv.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_charkiv.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.kharkiv_region.id,
@@ -698,8 +772,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_chernigiv.id,
                 "name": "Chernigivtravel",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_chernigiv.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_chernigiv.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.chernihiv_region.id,
@@ -718,8 +796,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_dnipro.id,
                 "name": "Dniprotrans",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_dnipro.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_dnipro.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.dnipro_region.id,
@@ -738,8 +820,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_kiev.id,
                 "name": "Kyivbud",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_kiev.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_kiev.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.kyiv_region.id,
@@ -769,8 +855,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_kiev.id,
                 "name": "Kyivbud",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_kiev.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_kiev.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.kyiv_region.id,
@@ -789,8 +879,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_dnipro.id,
                 "name": "Dniprotrans",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_dnipro.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_dnipro.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.dnipro_region.id,
@@ -809,8 +903,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_chernigiv.id,
                 "name": "Chernigivtravel",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_chernigiv.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_chernigiv.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.chernihiv_region.id,
@@ -829,8 +927,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_charkiv.id,
                 "name": "Charkivmarket",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_charkiv.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_charkiv.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.kharkiv_region.id,
@@ -861,8 +963,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_kiev.id,
                 "name": "Kyivbud",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_kiev.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_kiev.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.kyiv_region.id,
@@ -881,8 +987,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_dnipro.id,
                 "name": "Dniprotrans",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_dnipro.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_dnipro.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.dnipro_region.id,
@@ -901,8 +1011,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_chernigiv.id,
                 "name": "Chernigivtravel",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_chernigiv.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_chernigiv.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.chernihiv_region.id,
@@ -921,8 +1035,12 @@ class TestCompanyFilter(APITestCase):
             {
                 "id": self.company_charkiv.id,
                 "name": "Charkivmarket",
-                "categories": [],
-                "activities": [],
+                "categories": list(
+                    self.company_charkiv.categories.values("id", "name")
+                ),
+                "activities": list(
+                    self.company_charkiv.activities.values("id", "name")
+                ),
                 "regions": [
                     {
                         "id": self.kharkiv_region.id,

--- a/BackEnd/search/views.py
+++ b/BackEnd/search/views.py
@@ -10,7 +10,7 @@ from search.filters import CompanyFilter
 
 class SearchCompanyView(ListAPIView):
     queryset = (
-        Profile.objects.active_only()
+        Profile.objects.visible_only()
         .prefetch_related("regions", "categories", "activities")
         .order_by("id")
     )
@@ -37,7 +37,7 @@ class SearchCompanyView(ListAPIView):
 
 class AdvancedSearchView(ListAPIView):
     queryset = (
-        Profile.objects.active_only()
+        Profile.objects.visible_only()
         .prefetch_related("regions", "categories", "activities")
         .order_by("id")
     )


### PR DESCRIPTION
Added a visible_only method to the Profile manager to filter and display in lists only profiles with the required fields filled in - name, common info, categories and activities.

UPD.: official name was also added as a required field
