### PR TITLE
#1088 be unblock a user profile

### DIFF
--- a/BackEnd/profiles/serializers.py
+++ b/BackEnd/profiles/serializers.py
@@ -523,8 +523,8 @@ class ProfileModerationSerializer(serializers.Serializer):
             with transaction.atomic():
                 instance.status = instance.UNDEFINED
                 instance.is_deleted = False
-                delete_images(instance, 'banner', 'banner_approved')
-                delete_images(instance, 'logo', 'logo_approved')
+                delete_images(instance, "banner", "banner_approved")
+                delete_images(instance, "logo", "logo_approved")
                 instance.person.is_active = True
                 instance.person.save()
 

--- a/BackEnd/profiles/tests/test_unblock_moderation_request.py
+++ b/BackEnd/profiles/tests/test_unblock_moderation_request.py
@@ -54,7 +54,7 @@ class TestProfileModeration(APITestCase):
             },
         )
 
-        # moderator unlocks request
+        # moderator unblocks request
         response = self.moderator_client.patch(
             path="/api/profiles/{profile_id}/images_moderation/".format(
                 profile_id=encode_id(self.profile.id)
@@ -107,7 +107,7 @@ class TestProfileModeration(APITestCase):
             },
         )
 
-        # moderator unlock request
+        # moderator unblocks request
         response = self.moderator_client.patch(
             path="/api/profiles/{profile_id}/images_moderation/".format(
                 profile_id=encode_id(self.profile.id)
@@ -157,7 +157,7 @@ class TestProfileModeration(APITestCase):
             },
         )
 
-        # moderator unlock request
+        # moderator unblocks request
         response = self.moderator_client.patch(
             path="/api/profiles/{profile_id}/images_moderation/".format(
                 profile_id=encode_id(self.profile.id)
@@ -209,7 +209,7 @@ class TestProfileModeration(APITestCase):
             },
         )
 
-        # moderator unlocks request
+        # moderator unblocks request
         response = self.moderator_client.patch(
             path="/api/profiles/{profile_id}/images_moderation/".format(
                 profile_id=encode_id(self.profile.id)
@@ -259,7 +259,7 @@ class TestProfileModeration(APITestCase):
             },
         )
 
-        # moderator unlocks request
+        # moderator unblocks request
         response = self.moderator_client.patch(
             path="/api/profiles/{profile_id}/images_moderation/".format(
                 profile_id=encode_id(self.profile.id)
@@ -304,7 +304,7 @@ class TestProfileModeration(APITestCase):
             },
         )
 
-        # moderator rejects request
+        # moderator unblocks request
         response = self.moderator_client.patch(
             path="/api/profiles/{profile_id}/images_moderation/".format(
                 profile_id=encode_id(self.profile.id)

--- a/BackEnd/profiles/tests/test_unblock_moderation_request.py
+++ b/BackEnd/profiles/tests/test_unblock_moderation_request.py
@@ -1,0 +1,291 @@
+from unittest.mock import patch, call
+
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+
+from authentication.factories import UserFactory
+from profiles.factories import (
+    ProfileCompanyFactory,
+)
+from images.factories import ProfileimageFactory
+from utils.moderation.encode_decode_id import encode_id
+from utils.unittest_helper import AnyStr
+from utils.dump_response import dump  # noqa
+
+
+@patch("profiles.views.ModerationManager.schedule_autoapprove")
+@patch("profiles.views.ModerationManager.revoke_deprecated_autoapprove")
+class TestProfileModeration(APITestCase):
+    def setUp(self) -> None:
+        self.banner = ProfileimageFactory(image_type="banner")
+        self.logo = ProfileimageFactory(image_type="logo")
+        self.second_banner = ProfileimageFactory(image_type="banner")
+        self.second_logo = ProfileimageFactory(image_type="logo")
+        self.user = UserFactory()
+        self.profile = ProfileCompanyFactory.create(person=self.user)
+
+        self.user_client = APIClient()
+        self.user_client.force_authenticate(self.user)
+
+        self.moderator_client = APIClient()
+
+    def test_unblock_banner_and_logo(self, mock_revoke, mock_schedule):
+        # user updates both banner and logo
+        self.user_client.patch(
+            path="/api/profiles/{profile_id}".format(
+                profile_id=self.profile.id
+            ),
+            data={
+                "banner": self.banner.uuid,
+                "logo": self.logo.uuid,
+            },
+        )
+        self.profile.refresh_from_db()
+
+        # moderator rejects request
+        response = self.moderator_client.patch(
+            path="/api/profiles/{profile_id}/images_moderation/".format(
+                profile_id=encode_id(self.profile.id)
+            ),
+            data={
+                "banner": self.profile.banner.uuid,
+                "logo": self.profile.logo.uuid,
+                "action": "reject",
+            },
+        )
+
+        # moderator unlocks request
+        response = self.moderator_client.patch(
+            path="/api/profiles/{profile_id}/images_moderation/".format(
+                profile_id=encode_id(self.profile.id)
+            ),
+            data={
+                "banner": self.profile.banner.uuid,
+                "logo": self.profile.logo.uuid,
+                "action": "unblock",
+            },
+        )
+
+        self.profile.refresh_from_db()
+        self.user.refresh_from_db()
+        self.banner.refresh_from_db()
+        self.logo.refresh_from_db()
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(
+            {"status_updated_at": AnyStr(), "status": "undefined"},
+            response.json(),
+        )
+        self.assertTrue(self.banner.is_deleted)
+        self.assertTrue(self.logo.is_deleted)
+        self.assertIsNone(self.profile.banner)
+        self.assertIsNone(self.profile.logo)
+        self.assertEqual(self.profile.UNDEFINED, self.profile.status)
+        mock_schedule.assert_has_calls([call()])
+        mock_revoke.assert_has_calls([call(), call()])
+
+    def test_unblock_banner(self, mock_revoke, mock_schedule):
+        # user updates only banner
+        self.user_client.patch(
+            path="/api/profiles/{profile_id}".format(
+                profile_id=self.profile.id
+            ),
+            data={
+                "banner": self.banner.uuid,
+            },
+        )
+        self.profile.refresh_from_db()
+
+        # moderator rejects request
+        response = self.moderator_client.patch(
+            path="/api/profiles/{profile_id}/images_moderation/".format(
+                profile_id=encode_id(self.profile.id)
+            ),
+            data={
+                "banner": self.profile.banner.uuid,
+                "action": "reject",
+            },
+        )
+
+        # moderator unlock request
+        response = self.moderator_client.patch(
+            path="/api/profiles/{profile_id}/images_moderation/".format(
+                profile_id=encode_id(self.profile.id)
+            ),
+            data={
+                "banner": self.profile.banner.uuid,
+                "action": "unblock",
+            },
+        )
+
+        self.profile.refresh_from_db()
+        self.user.refresh_from_db()
+        self.banner.refresh_from_db()
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(
+            {"status_updated_at": AnyStr(), "status": "undefined"},
+            response.json(),
+        )
+        self.assertTrue(self.banner.is_deleted)
+        self.assertEqual(self.profile.UNDEFINED, self.profile.status)
+        self.assertFalse(self.profile.is_deleted)
+        self.assertTrue(self.user.is_active)
+        mock_schedule.assert_has_calls([call()])
+        mock_revoke.assert_has_calls([call(), call()])
+
+    def test_unblock_logo(self, mock_revoke, mock_schedule):
+        # user updates only logo
+        self.user_client.patch(
+            path="/api/profiles/{profile_id}".format(
+                profile_id=self.profile.id
+            ),
+            data={
+                "logo": self.logo.uuid,
+            },
+        )
+        self.profile.refresh_from_db()
+
+        # moderator rejects request
+        response = self.moderator_client.patch(
+            path="/api/profiles/{profile_id}/images_moderation/".format(
+                profile_id=encode_id(self.profile.id)
+            ),
+            data={
+                "logo": self.profile.logo.uuid,
+                "action": "reject",
+            },
+        )
+
+        # moderator unlock request
+        response = self.moderator_client.patch(
+            path="/api/profiles/{profile_id}/images_moderation/".format(
+                profile_id=encode_id(self.profile.id)
+            ),
+            data={
+                "logo": self.profile.logo.uuid,
+                "action": "unblock",
+            },
+        )
+
+        self.profile.refresh_from_db()
+        self.user.refresh_from_db()
+        self.logo.refresh_from_db()
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(
+            {"status_updated_at": AnyStr(), "status": "undefined"},
+            response.json(),
+        )
+        self.assertTrue(self.logo.is_deleted)
+        self.assertEqual(self.profile.UNDEFINED, self.profile.status)
+        self.assertFalse(self.profile.is_deleted)
+        self.assertTrue(self.user.is_active)
+        mock_schedule.assert_has_calls([call()])
+        mock_revoke.assert_has_calls([call(), call()])
+
+    def test_not_blocked_profile(self, mock_revoke, mock_schedule):
+        # user updates both banner and logo
+        self.user_client.patch(
+            path="/api/profiles/{profile_id}".format(
+                profile_id=self.profile.id
+            ),
+            data={
+                "banner": self.banner.uuid,
+                "logo": self.logo.uuid,
+            },
+        )
+        self.profile.refresh_from_db()
+
+        # moderator approves request
+        response = self.moderator_client.patch(
+            path="/api/profiles/{profile_id}/images_moderation/".format(
+                profile_id=encode_id(self.profile.id)
+            ),
+            data={
+                "banner": self.profile.banner.uuid,
+                "logo": self.profile.logo.uuid,
+                "action": "approve",
+            },
+        )
+
+        # moderator unlocks request
+        response = self.moderator_client.patch(
+            path="/api/profiles/{profile_id}/images_moderation/".format(
+                profile_id=encode_id(self.profile.id)
+            ),
+            data={
+                "banner": self.profile.banner.uuid,
+                "logo": self.profile.logo.uuid,
+                "action": "unblock",
+            },
+        )
+
+        self.profile.refresh_from_db()
+        self.banner.refresh_from_db()
+        self.logo.refresh_from_db()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            {"non_field_errors": ["The profile is not blocked"]},
+            response.json(),
+        )
+        self.assertEqual(self.profile.APPROVED, self.profile.status)
+        mock_schedule.assert_called_once()
+        mock_revoke.assert_called_once()
+
+    def test_login_unblocked_user(self, mock_revoke, mock_schedule):
+        # user updates both banner and logo
+        self.user_client.patch(
+            path="/api/profiles/{profile_id}".format(
+                profile_id=self.profile.id
+            ),
+            data={
+                "banner": self.banner.uuid,
+                "logo": self.logo.uuid,
+            },
+        )
+        self.profile.refresh_from_db()
+
+        # moderator rejects request
+        self.moderator_client.patch(
+            path="/api/profiles/{profile_id}/images_moderation/".format(
+                profile_id=encode_id(self.profile.id)
+            ),
+            data={
+                "banner": self.profile.banner.uuid,
+                "logo": self.profile.logo.uuid,
+                "action": "reject",
+            },
+        )
+
+        # moderator unlocks request
+        response = self.moderator_client.patch(
+            path="/api/profiles/{profile_id}/images_moderation/".format(
+                profile_id=encode_id(self.profile.id)
+            ),
+            data={
+                "banner": self.profile.banner.uuid,
+                "logo": self.profile.logo.uuid,
+                "action": "unblock",
+            },
+        )
+
+        self.user.refresh_from_db()
+        self.user.set_password("Test1234")
+        self.user.save()
+
+        # user with unblocked profile tries to log in
+        response = self.user_client.post(
+            path="/api/auth/token/login/",
+            data={
+                "email": "test5@test.com",
+                "password": "Test1234",
+                "captcha": "dummy_captcha",
+            },
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual({"auth_token": AnyStr()}, response.json())
+        self.assertContains(response, "auth_token")
+        mock_schedule.assert_has_calls([call()])
+        mock_revoke.assert_has_calls([call(), call()])

--- a/BackEnd/utils/moderation/moderation_action.py
+++ b/BackEnd/utils/moderation/moderation_action.py
@@ -1,10 +1,12 @@
 class ModerationAction:
     approve = "approve"
     reject = "reject"
+    unblock = "unblock"
 
     @classmethod
     def choices(cls):
         return [
             (cls.approve, "approve"),
             (cls.reject, "reject"),
+            (cls.unblock, "unblock"),
         ]

--- a/BackEnd/utils/moderation/unblock_helper.py
+++ b/BackEnd/utils/moderation/unblock_helper.py
@@ -1,0 +1,13 @@
+def delete_images(profile, image_type, approved_image_type):
+    image = getattr(profile, image_type, None)
+    approved_image = getattr(profile, approved_image_type, None)
+
+    if image:
+        image.is_deleted = True
+        image.save()
+        setattr(profile, image_type, None)
+
+    if approved_image:
+        approved_image.is_deleted = True
+        approved_image.save()
+        setattr(profile, approved_image_type, None)

--- a/BackEnd/utils/moderation/unblock_helper.py
+++ b/BackEnd/utils/moderation/unblock_helper.py
@@ -10,4 +10,3 @@ def delete_images(profile, image_type, approved_image_type):
     if approved_image:
         approved_image.is_deleted = True
         approved_image.save()
-        setattr(profile, approved_image_type, None)


### PR DESCRIPTION
An unblock action has been added, allowing the user to log in again after being unblocked. Upon unblocking, the user's images will be deleted, and the `banner` and `logo` fields will be set to None, the users's status will be set to `undefined`.