### PR TITLE
saving e-mail during administrator registration

### DIFF
--- a/BackEnd/administration/serializers.py
+++ b/BackEnd/administration/serializers.py
@@ -69,7 +69,7 @@ class AdminRegistrationSerializer(serializers.Serializer):
     def create(self, validated_data):
         email = validated_data.get("email").lower()
         password = generate_password()
-        
+
         admin = User.objects.create(
             email=email,
             is_staff=True,

--- a/BackEnd/administration/serializers.py
+++ b/BackEnd/administration/serializers.py
@@ -67,8 +67,9 @@ class AdminRegistrationSerializer(serializers.Serializer):
         return value
 
     def create(self, validated_data):
-        email = validated_data.get("email")
+        email = validated_data.get("email").lower()
         password = generate_password()
+        
         admin = User.objects.create(
             email=email,
             is_staff=True,


### PR DESCRIPTION
The current implementation of admin registration allows emails to be stored in a case-sensitive manner.
This must be fixed so that emails are stored in lowercase.