### PR TITLE
[Registration, Edit Profile] Adjusted name and surname fields validation

### DIFF
--- a/FrontEnd/src/constants/constants.js
+++ b/FrontEnd/src/constants/constants.js
@@ -1,6 +1,7 @@
 export const EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 export const PASSWORD_PATTERN = /^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9]{8,128}$/;
-export const NAME_SURNAME_PATTERN = /^(?=.{2,50}$)[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ']+(\s[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ']+)*$/;
+export const ALLOWED_NAME_SURNAME_SYMBOLS_PATTERN = /^\s*[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]+(?:'[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]+)?(?:[- ]+[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]+(?:'[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]+)?)*\s*$/;
+export const NAME_SURNAME_PATTERN = /^(?!.* {2})(?!.*-.*-)(?=.{2,50}$)[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]+(?:'[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]+)?(?:-[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]+(?:'[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]+)?)?(?: [a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]+(?:'[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]+)?)?$/;
 export const COMPANY_NAME_PATTERN = /^.{2,100}$/;
 export const CONTACT_COMPANY_NAME_PATTERN = /^[а-яА-ЯіІїЇєЄґҐa-zA-Z0-9\s'"`.,-]*$/;
 export const PHONE_PATTERN = /^\+380\d{2} \d{3} \d{2} \d{2}$/;

--- a/FrontEnd/src/pages/ProfilePage/FormComponents/UserInfo.jsx
+++ b/FrontEnd/src/pages/ProfilePage/FormComponents/UserInfo.jsx
@@ -9,6 +9,7 @@ import defineChanges from '../../../utils/defineChanges';
 import HalfFormField from './FormFields/HalfFormField';
 import Loader from '../../../components/Loader/Loader';
 import ProfileFormButton from '../UI/ProfileFormButton/ProfileFormButton';
+import { ALLOWED_NAME_SURNAME_SYMBOLS_PATTERN } from '../../../constants/constants';
 import css from './FormComponents.module.css';
 
 const LABELS = {
@@ -64,8 +65,8 @@ const UserInfo = (props) => {
     let errorMessage = [];
     const allowedSymbolsPatterns = {
       person_position: /^[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ\-'\s]+$/,
-      name: /^[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ'\s]+$/,
-      surname: /^[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ'\s]+$/,
+      name: ALLOWED_NAME_SURNAME_SYMBOLS_PATTERN,
+      surname: ALLOWED_NAME_SURNAME_SYMBOLS_PATTERN,
     };
     const letterCount = (
       fieldValue.match(/[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]/g) || []

--- a/FrontEnd/src/pages/SignUp/SignupForm/SignUpFormContent.jsx
+++ b/FrontEnd/src/pages/SignUp/SignupForm/SignUpFormContent.jsx
@@ -13,6 +13,7 @@ import styles from './SignUpFormContent.module.css';
 import {
   EMAIL_PATTERN,
   PASSWORD_PATTERN,
+  ALLOWED_NAME_SURNAME_SYMBOLS_PATTERN,
   NAME_SURNAME_PATTERN,
   COMPANY_NAME_PATTERN,
 } from '../../../constants/constants';
@@ -66,10 +67,9 @@ export function SignUpFormContentComponent(props) {
   };
 
   const validateNameSurname = (value) => {
-    const allowedSymbolsPattern = /^[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ'\s]+$/;
     const letterCount = (value.match(/[a-zA-Zа-щюяьА-ЩЮЯЬїЇіІєЄґҐ]/g) || [])
       .length;
-    if (!allowedSymbolsPattern.test(value)) {
+    if (!ALLOWED_NAME_SURNAME_SYMBOLS_PATTERN.test(value)) {
       return errorMessageTemplates.notAllowedSymbols;
     }
     if (letterCount < 2) {


### PR DESCRIPTION
Added hyphen as an allowed symbol in name and surname fields. Now, double names and surnames are supported.